### PR TITLE
Credentials_and_Composite_Download_Indent_Bug_Fixes

### DIFF
--- a/log/test_windows_installation_20230603.txt
+++ b/log/test_windows_installation_20230603.txt
@@ -1,0 +1,556 @@
+2023-06-06 17:57:06,436: INFO: ---------------------------------------------------------------
+2023-06-06 17:57:06,436: INFO:                     ****PROCESSING START****
+2023-06-06 17:57:06,437: INFO: ---------------------------------------------------------------
+2023-06-06 17:57:06,437: INFO: C:\Users\ir81\.conda\envs\envs\pyeo_env_pcwe
+2023-06-06 17:57:06,438: INFO: False
+2023-06-06 17:57:06,439: ERROR: Conda Environment Directory does not exist
+2023-06-06 17:57:06,439: ERROR: Ensure this exists
+2023-06-06 17:57:06,439: ERROR: now exiting the pipeline
+2023-06-06 21:39:35,556: INFO: ---------------------------------------------------------------
+2023-06-06 21:39:35,557: INFO:                     ****PROCESSING START****
+2023-06-06 21:39:35,558: INFO: ---------------------------------------------------------------
+2023-06-06 21:39:35,559: INFO: C:\Users\ir81\.conda\envs\pyeo_env_pcwe
+2023-06-06 21:39:35,559: INFO: True
+2023-06-06 21:39:35,560: INFO: ---------------------------------------------------------------
+2023-06-06 21:39:35,561: INFO: ---                  INTEGRATED PROCESSING START            ---
+2023-06-06 21:39:35,562: INFO: ---------------------------------------------------------------
+2023-06-06 21:39:35,563: INFO: Reading in parameters defined in: pyeo_windows.ini
+2023-06-06 21:39:35,563: INFO: ---------------------------------------------------------------
+2023-06-06 21:39:35,564: INFO: ---------------------------------------------------------------
+2023-06-06 21:39:35,565: INFO: Starting acd_config_to_log()
+2023-06-06 21:39:35,565: INFO: ---------------------------------------------------------------
+2023-06-06 21:39:35,565: INFO: Options:
+2023-06-06 21:39:35,566: INFO:   --dev Running in development mode, choosing development versions of functions where available
+2023-06-06 21:39:35,566: INFO:   -do_tile_intersection
+2023-06-06 21:39:35,567: INFO:       Sentinel-2 tile intersection with ROI enabled
+2023-06-06 21:39:35,567: INFO:   --do_raster
+2023-06-06 21:39:35,567: INFO:       raster pipeline enabled
+2023-06-06 21:39:35,568: INFO:   --build_composite for baseline composite
+2023-06-06 21:39:35,568: INFO:   --download_source = scihub
+2023-06-06 21:39:35,569: INFO:          composite start date  : 20230101
+2023-06-06 21:39:35,569: INFO:          composite end date  : 20230331
+2023-06-06 21:39:35,570: INFO:   --do_delete_existing_vector , when vectorising the change report rasters, 
+2023-06-06 21:39:35,570: INFO:             existing vectors files will be deleted and new vector files created.
+2023-06-06 21:39:35,571: INFO: EPSG used is: 21097
+2023-06-06 21:39:35,571: INFO: List of image bands: ['B02', 'B03', 'B04', 'B08']
+2023-06-06 21:39:35,571: INFO: Model used: .\models\model_36MYE_Unoptimised_20230505_no_haze.pkl
+2023-06-06 21:39:35,572: INFO: 
+2023-06-06 21:39:35,572: INFO: List of class labels:
+2023-06-06 21:39:35,573: INFO:   1 : primary forest
+2023-06-06 21:39:35,573: INFO:   2 : plantation forest
+2023-06-06 21:39:35,574: INFO:   3 : bare soil
+2023-06-06 21:39:35,574: INFO:   4 : crops
+2023-06-06 21:39:35,574: INFO:   5 : grassland
+2023-06-06 21:39:35,575: INFO:   6 : open water
+2023-06-06 21:39:35,575: INFO:   7 : burn scar
+2023-06-06 21:39:35,576: INFO:   8 : cloud
+2023-06-06 21:39:35,581: INFO:   9 : cloud shadow
+2023-06-06 21:39:35,582: INFO:   10 : haze
+2023-06-06 21:39:35,582: INFO:   11 : sparse woodland
+2023-06-06 21:39:35,582: INFO:   12 : dense woodland
+2023-06-06 21:39:35,583: INFO:   13 : artificial
+2023-06-06 21:39:35,583: INFO: Detecting changes from any of the classes: [1, 2]
+2023-06-06 21:39:35,583: INFO:                     to any of the classes: [3]
+2023-06-06 21:39:35,584: INFO: ------------------------------------------------------------
+2023-06-06 21:39:35,584: INFO: Reporting Directories and Filepaths
+2023-06-06 21:39:35,584: INFO: Tile Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\data_folder
+2023-06-06 21:39:35,585: INFO: Working Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\pyeo_1
+2023-06-06 21:39:35,585: INFO: The following directories are relative to the working directory, i.e. stored underneath:
+2023-06-06 21:39:35,585: INFO: Integrated Directory is   : .\integrated
+2023-06-06 21:39:35,586: INFO: ROI Directory is   : .\roi
+2023-06-06 21:39:35,586: INFO: Geometry Directory is   : .\geometry
+2023-06-06 21:39:35,586: INFO: Path to the Administrative Boundaries used in the Change Report Vectorisation   : .\geometry\gadm41_KEN_1.json
+2023-06-06 21:39:35,586: INFO: Path to Sen2Cor is   : C:\Users\ir81\Sen2Cor-02.11.00-win64\L2A_Process
+2023-06-06 21:39:35,587: INFO: The Conda Environment specified in .ini file is :  pyeo_env_pcwe
+2023-06-06 21:39:35,587: INFO: -------------------------------------------
+2023-06-06 21:39:35,587: INFO: -------------------------------------------
+2023-06-06 21:39:35,587: INFO: ---------------------------------------------------------------
+2023-06-06 21:39:35,588: INFO: Starting acd_roi_tile_intersection()
+2023-06-06 21:39:35,588: INFO: ---------------------------------------------------------------
+2023-06-06 21:39:40,759: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-06 21:39:40,760: INFO: These tiles are  :
+2023-06-06 21:39:40,765: INFO:   1 : 36NXG
+2023-06-06 21:39:40,765: INFO:   2 : 36NYG
+2023-06-06 21:39:40,766: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-06 21:39:40,796: INFO: Finished ROI tile intersection
+2023-06-06 21:39:40,978: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-06 21:39:40,979: INFO: These tiles are  :
+2023-06-06 21:39:40,980: INFO:   1 : 36NXG
+2023-06-06 21:39:40,981: INFO:   2 : 36NYG
+2023-06-06 21:39:40,981: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-06 21:39:41,002: INFO: Finished ROI tile intersection
+2023-06-06 21:39:41,003: INFO: ---------------------------------------------------------------
+2023-06-06 21:39:41,004: INFO: Starting acd_integrated_raster():
+2023-06-06 21:39:41,005: INFO: ---------------------------------------------------------------
+2023-06-06 21:39:41,017: ERROR: .\credentials\credentials_ir.ini does not exist, did you write the correct filepath in pyeo_1.ini?
+2023-06-06 21:39:41,018: INFO: Starting ACD Raster Processes for Tile :  36NXG
+2023-06-06 21:40:44,396: INFO: ---------------------------------------------------------------
+2023-06-06 21:40:44,397: INFO:                     ****PROCESSING START****
+2023-06-06 21:40:44,398: INFO: ---------------------------------------------------------------
+2023-06-06 21:40:44,399: INFO: C:\Users\ir81\.conda\envs\pyeo_env_pcwe
+2023-06-06 21:40:44,400: INFO: True
+2023-06-06 21:40:44,401: INFO: ---------------------------------------------------------------
+2023-06-06 21:40:44,401: INFO: ---                  INTEGRATED PROCESSING START            ---
+2023-06-06 21:40:44,402: INFO: ---------------------------------------------------------------
+2023-06-06 21:40:44,402: INFO: Reading in parameters defined in: pyeo_windows.ini
+2023-06-06 21:40:44,403: INFO: ---------------------------------------------------------------
+2023-06-06 21:40:44,403: INFO: ---------------------------------------------------------------
+2023-06-06 21:40:44,404: INFO: Starting acd_config_to_log()
+2023-06-06 21:40:44,404: INFO: ---------------------------------------------------------------
+2023-06-06 21:40:44,404: INFO: Options:
+2023-06-06 21:40:44,405: INFO:   --dev Running in development mode, choosing development versions of functions where available
+2023-06-06 21:40:44,406: INFO:   -do_tile_intersection
+2023-06-06 21:40:44,406: INFO:       Sentinel-2 tile intersection with ROI enabled
+2023-06-06 21:40:44,406: INFO:   --do_raster
+2023-06-06 21:40:44,406: INFO:       raster pipeline enabled
+2023-06-06 21:40:44,407: INFO:   --build_composite for baseline composite
+2023-06-06 21:40:44,407: INFO:   --download_source = scihub
+2023-06-06 21:40:44,408: INFO:          composite start date  : 20230101
+2023-06-06 21:40:44,408: INFO:          composite end date  : 20230331
+2023-06-06 21:40:44,409: INFO:   --do_delete_existing_vector , when vectorising the change report rasters, 
+2023-06-06 21:40:44,409: INFO:             existing vectors files will be deleted and new vector files created.
+2023-06-06 21:40:44,409: INFO: EPSG used is: 21097
+2023-06-06 21:40:44,410: INFO: List of image bands: ['B02', 'B03', 'B04', 'B08']
+2023-06-06 21:40:44,410: INFO: Model used: .\models\model_36MYE_Unoptimised_20230505_no_haze.pkl
+2023-06-06 21:40:44,410: INFO: 
+2023-06-06 21:40:44,411: INFO: List of class labels:
+2023-06-06 21:40:44,411: INFO:   1 : primary forest
+2023-06-06 21:40:44,411: INFO:   2 : plantation forest
+2023-06-06 21:40:44,412: INFO:   3 : bare soil
+2023-06-06 21:40:44,412: INFO:   4 : crops
+2023-06-06 21:40:44,412: INFO:   5 : grassland
+2023-06-06 21:40:44,413: INFO:   6 : open water
+2023-06-06 21:40:44,413: INFO:   7 : burn scar
+2023-06-06 21:40:44,414: INFO:   8 : cloud
+2023-06-06 21:40:44,420: INFO:   9 : cloud shadow
+2023-06-06 21:40:44,420: INFO:   10 : haze
+2023-06-06 21:40:44,420: INFO:   11 : sparse woodland
+2023-06-06 21:40:44,420: INFO:   12 : dense woodland
+2023-06-06 21:40:44,420: INFO:   13 : artificial
+2023-06-06 21:40:44,421: INFO: Detecting changes from any of the classes: [1, 2]
+2023-06-06 21:40:44,421: INFO:                     to any of the classes: [3]
+2023-06-06 21:40:44,421: INFO: ------------------------------------------------------------
+2023-06-06 21:40:44,422: INFO: Reporting Directories and Filepaths
+2023-06-06 21:40:44,423: INFO: Tile Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\data_folder
+2023-06-06 21:40:44,423: INFO: Working Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\pyeo_1
+2023-06-06 21:40:44,423: INFO: The following directories are relative to the working directory, i.e. stored underneath:
+2023-06-06 21:40:44,423: INFO: Integrated Directory is   : .\integrated
+2023-06-06 21:40:44,424: INFO: ROI Directory is   : .\roi
+2023-06-06 21:40:44,424: INFO: Geometry Directory is   : .\geometry
+2023-06-06 21:40:44,424: INFO: Path to the Administrative Boundaries used in the Change Report Vectorisation   : .\geometry\gadm41_KEN_1.json
+2023-06-06 21:40:44,424: INFO: Path to Sen2Cor is   : C:\Users\ir81\Sen2Cor-02.11.00-win64\L2A_Process
+2023-06-06 21:40:44,425: INFO: The Conda Environment specified in .ini file is :  pyeo_env_pcwe
+2023-06-06 21:40:44,425: INFO: -------------------------------------------
+2023-06-06 21:40:44,425: INFO: -------------------------------------------
+2023-06-06 21:40:44,426: INFO: ---------------------------------------------------------------
+2023-06-06 21:40:44,426: INFO: Starting acd_roi_tile_intersection()
+2023-06-06 21:40:44,426: INFO: ---------------------------------------------------------------
+2023-06-06 21:40:45,036: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-06 21:40:45,037: INFO: These tiles are  :
+2023-06-06 21:40:45,038: INFO:   1 : 36NXG
+2023-06-06 21:40:45,038: INFO:   2 : 36NYG
+2023-06-06 21:40:45,039: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-06 21:40:45,048: INFO: Finished ROI tile intersection
+2023-06-06 21:40:45,191: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-06 21:40:45,192: INFO: These tiles are  :
+2023-06-06 21:40:45,194: INFO:   1 : 36NXG
+2023-06-06 21:40:45,194: INFO:   2 : 36NYG
+2023-06-06 21:40:45,194: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-06 21:40:45,206: INFO: Finished ROI tile intersection
+2023-06-06 21:40:45,207: INFO: ---------------------------------------------------------------
+2023-06-06 21:40:45,208: INFO: Starting acd_integrated_raster():
+2023-06-06 21:40:45,209: INFO: ---------------------------------------------------------------
+2023-06-06 21:40:45,242: INFO: Starting ACD Raster Processes for Tile :  36NXG
+2023-06-06 22:05:15,943: INFO: Finished ACD Raster Processes for Tile :  36NXG
+2023-06-06 22:05:15,981: INFO: Starting ACD Raster Processes for Tile :  36NYG
+2023-06-07 03:02:58,866: INFO: Finished ACD Raster Processes for Tile :  36NYG
+2023-06-07 03:02:58,878: INFO: ---------------------------------------------------------------
+2023-06-07 03:02:58,879: INFO: ---                  INTEGRATED PROCESSING END              ---
+2023-06-07 03:02:58,880: INFO: ---------------------------------------------------------------
+2023-06-07 11:02:32,714: INFO: ---------------------------------------------------------------
+2023-06-07 11:02:32,716: INFO:                     ****PROCESSING START****
+2023-06-07 11:02:32,716: INFO: ---------------------------------------------------------------
+2023-06-07 11:02:32,717: INFO: C:\Users\ir81\.conda\envs\pyeo_env_pcwe
+2023-06-07 11:02:32,717: INFO: True
+2023-06-07 11:02:32,718: INFO: ---------------------------------------------------------------
+2023-06-07 11:02:32,719: INFO: ---                  INTEGRATED PROCESSING START            ---
+2023-06-07 11:02:32,719: INFO: ---------------------------------------------------------------
+2023-06-07 11:02:32,719: INFO: Reading in parameters defined in: pyeo_windows.ini
+2023-06-07 11:02:32,719: INFO: ---------------------------------------------------------------
+2023-06-07 11:02:32,720: INFO: ---------------------------------------------------------------
+2023-06-07 11:02:32,720: INFO: Starting acd_config_to_log()
+2023-06-07 11:02:32,720: INFO: ---------------------------------------------------------------
+2023-06-07 11:02:32,721: INFO: Options:
+2023-06-07 11:02:32,721: INFO:   --dev Running in development mode, choosing development versions of functions where available
+2023-06-07 11:02:32,721: INFO:   -do_tile_intersection
+2023-06-07 11:02:32,722: INFO:       Sentinel-2 tile intersection with ROI enabled
+2023-06-07 11:02:32,722: INFO:   --do_raster
+2023-06-07 11:02:32,723: INFO:       raster pipeline enabled
+2023-06-07 11:02:32,723: INFO:   --download for change detection images
+2023-06-07 11:02:32,723: INFO:   --download_source = scihub
+2023-06-07 11:02:32,724: INFO:   Faulty Granule Threshold  : 350
+2023-06-07 11:02:32,728: INFO:   --do_delete_existing_vector , when vectorising the change report rasters, 
+2023-06-07 11:02:32,729: INFO:             existing vectors files will be deleted and new vector files created.
+2023-06-07 11:02:32,730: INFO: EPSG used is: 21097
+2023-06-07 11:02:32,732: INFO: List of image bands: ['B02', 'B03', 'B04', 'B08']
+2023-06-07 11:02:32,732: INFO: Model used: .\models\model_36MYE_Unoptimised_20230505_no_haze.pkl
+2023-06-07 11:02:32,732: INFO: 
+2023-06-07 11:02:32,733: INFO: List of class labels:
+2023-06-07 11:02:32,733: INFO:   1 : primary forest
+2023-06-07 11:02:32,734: INFO:   2 : plantation forest
+2023-06-07 11:02:32,734: INFO:   3 : bare soil
+2023-06-07 11:02:32,735: INFO:   4 : crops
+2023-06-07 11:02:32,735: INFO:   5 : grassland
+2023-06-07 11:02:32,735: INFO:   6 : open water
+2023-06-07 11:02:32,735: INFO:   7 : burn scar
+2023-06-07 11:02:32,736: INFO:   8 : cloud
+2023-06-07 11:02:32,736: INFO:   9 : cloud shadow
+2023-06-07 11:02:32,736: INFO:   10 : haze
+2023-06-07 11:02:32,737: INFO:   11 : sparse woodland
+2023-06-07 11:02:32,738: INFO:   12 : dense woodland
+2023-06-07 11:02:32,738: INFO:   13 : artificial
+2023-06-07 11:02:32,738: INFO: Detecting changes from any of the classes: [1, 2]
+2023-06-07 11:02:32,738: INFO:                     to any of the classes: [3]
+2023-06-07 11:02:32,739: INFO: ------------------------------------------------------------
+2023-06-07 11:02:32,739: INFO: Reporting Directories and Filepaths
+2023-06-07 11:02:32,739: INFO: Tile Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\data_folder
+2023-06-07 11:02:32,743: INFO: Working Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\pyeo_1
+2023-06-07 11:02:32,744: INFO: The following directories are relative to the working directory, i.e. stored underneath:
+2023-06-07 11:02:32,744: INFO: Integrated Directory is   : .\integrated
+2023-06-07 11:02:32,745: INFO: ROI Directory is   : .\roi
+2023-06-07 11:02:32,745: INFO: Geometry Directory is   : .\geometry
+2023-06-07 11:02:32,746: INFO: Path to the Administrative Boundaries used in the Change Report Vectorisation   : .\geometry\gadm41_KEN_1.json
+2023-06-07 11:02:32,746: INFO: Path to Sen2Cor is   : C:\Users\ir81\Sen2Cor-02.11.00-win64\L2A_Process
+2023-06-07 11:02:32,747: INFO: The Conda Environment specified in .ini file is :  pyeo_env_pcwe
+2023-06-07 11:02:32,748: INFO: -------------------------------------------
+2023-06-07 11:02:32,748: INFO: -------------------------------------------
+2023-06-07 11:02:32,749: INFO: ---------------------------------------------------------------
+2023-06-07 11:02:32,749: INFO: Starting acd_roi_tile_intersection()
+2023-06-07 11:02:32,750: INFO: ---------------------------------------------------------------
+2023-06-07 11:02:37,723: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-07 11:02:37,723: INFO: These tiles are  :
+2023-06-07 11:02:37,725: INFO:   1 : 36NXG
+2023-06-07 11:02:37,725: INFO:   2 : 36NYG
+2023-06-07 11:02:37,726: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-07 11:02:37,744: INFO: Finished ROI tile intersection
+2023-06-07 11:02:37,899: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-07 11:02:37,900: INFO: These tiles are  :
+2023-06-07 11:02:37,901: INFO:   1 : 36NXG
+2023-06-07 11:02:37,901: INFO:   2 : 36NYG
+2023-06-07 11:02:37,902: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-07 11:02:37,921: INFO: Finished ROI tile intersection
+2023-06-07 11:02:37,922: INFO: ---------------------------------------------------------------
+2023-06-07 11:02:37,923: INFO: Starting acd_integrated_raster():
+2023-06-07 11:02:37,923: INFO: ---------------------------------------------------------------
+2023-06-07 11:02:37,954: INFO: Starting ACD Raster Processes for Tile :  36NXG
+2023-06-07 11:42:34,797: INFO: ---------------------------------------------------------------
+2023-06-07 11:42:34,798: INFO:                     ****PROCESSING START****
+2023-06-07 11:42:34,803: INFO: ---------------------------------------------------------------
+2023-06-07 11:42:34,804: INFO: C:\Users\ir81\.conda\envs\pyeo_env_pcwe
+2023-06-07 11:42:34,805: INFO: True
+2023-06-07 11:42:34,805: INFO: ---------------------------------------------------------------
+2023-06-07 11:42:34,805: INFO: ---                  INTEGRATED PROCESSING START            ---
+2023-06-07 11:42:34,806: INFO: ---------------------------------------------------------------
+2023-06-07 11:42:34,806: INFO: Reading in parameters defined in: pyeo_windows.ini
+2023-06-07 11:42:34,806: INFO: ---------------------------------------------------------------
+2023-06-07 11:42:34,807: INFO: ---------------------------------------------------------------
+2023-06-07 11:42:34,807: INFO: Starting acd_config_to_log()
+2023-06-07 11:42:34,807: INFO: ---------------------------------------------------------------
+2023-06-07 11:42:34,807: INFO: Options:
+2023-06-07 11:42:34,808: INFO:   --dev Running in development mode, choosing development versions of functions where available
+2023-06-07 11:42:34,808: INFO:   -do_tile_intersection
+2023-06-07 11:42:34,808: INFO:       Sentinel-2 tile intersection with ROI enabled
+2023-06-07 11:42:34,809: INFO:   --do_raster
+2023-06-07 11:42:34,809: INFO:       raster pipeline enabled
+2023-06-07 11:42:34,809: INFO:   --download for change detection images
+2023-06-07 11:42:34,810: INFO:   --download_source = scihub
+2023-06-07 11:42:34,810: INFO:   Faulty Granule Threshold  : 350
+2023-06-07 11:42:34,810: INFO:   --do_delete_existing_vector , when vectorising the change report rasters, 
+2023-06-07 11:42:34,811: INFO:             existing vectors files will be deleted and new vector files created.
+2023-06-07 11:42:34,814: INFO: EPSG used is: 21097
+2023-06-07 11:42:34,815: INFO: List of image bands: ['B02', 'B03', 'B04', 'B08']
+2023-06-07 11:42:34,815: INFO: Model used: .\models\model_36MYE_Unoptimised_20230505_no_haze.pkl
+2023-06-07 11:42:34,816: INFO: 
+2023-06-07 11:42:34,816: INFO: List of class labels:
+2023-06-07 11:42:34,817: INFO:   1 : primary forest
+2023-06-07 11:42:34,817: INFO:   2 : plantation forest
+2023-06-07 11:42:34,818: INFO:   3 : bare soil
+2023-06-07 11:42:34,819: INFO:   4 : crops
+2023-06-07 11:42:34,820: INFO:   5 : grassland
+2023-06-07 11:42:34,820: INFO:   6 : open water
+2023-06-07 11:42:34,821: INFO:   7 : burn scar
+2023-06-07 11:42:34,821: INFO:   8 : cloud
+2023-06-07 11:42:34,822: INFO:   9 : cloud shadow
+2023-06-07 11:42:34,822: INFO:   10 : haze
+2023-06-07 11:42:34,823: INFO:   11 : sparse woodland
+2023-06-07 11:42:34,823: INFO:   12 : dense woodland
+2023-06-07 11:42:34,823: INFO:   13 : artificial
+2023-06-07 11:42:34,824: INFO: Detecting changes from any of the classes: [1, 2]
+2023-06-07 11:42:34,824: INFO:                     to any of the classes: [3]
+2023-06-07 11:42:34,825: INFO: ------------------------------------------------------------
+2023-06-07 11:42:34,825: INFO: Reporting Directories and Filepaths
+2023-06-07 11:42:34,825: INFO: Tile Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\data_folder
+2023-06-07 11:42:34,826: INFO: Working Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\pyeo_1
+2023-06-07 11:42:34,826: INFO: The following directories are relative to the working directory, i.e. stored underneath:
+2023-06-07 11:42:34,827: INFO: Integrated Directory is   : .\integrated
+2023-06-07 11:42:34,832: INFO: ROI Directory is   : .\roi
+2023-06-07 11:42:34,832: INFO: Geometry Directory is   : .\geometry
+2023-06-07 11:42:34,833: INFO: Path to the Administrative Boundaries used in the Change Report Vectorisation   : .\geometry\gadm41_KEN_1.json
+2023-06-07 11:42:34,833: INFO: Path to Sen2Cor is   : C:\Users\ir81\Sen2Cor-02.11.00-win64\L2A_Process
+2023-06-07 11:42:34,834: INFO: The Conda Environment specified in .ini file is :  pyeo_env_pcwe
+2023-06-07 11:42:34,835: INFO: -------------------------------------------
+2023-06-07 11:42:34,836: INFO: -------------------------------------------
+2023-06-07 11:42:34,837: INFO: ---------------------------------------------------------------
+2023-06-07 11:42:34,837: INFO: Starting acd_roi_tile_intersection()
+2023-06-07 11:42:34,837: INFO: ---------------------------------------------------------------
+2023-06-07 11:42:35,643: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-07 11:42:35,644: INFO: These tiles are  :
+2023-06-07 11:42:35,646: INFO:   1 : 36NXG
+2023-06-07 11:42:35,646: INFO:   2 : 36NYG
+2023-06-07 11:42:35,646: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-07 11:42:35,661: INFO: Finished ROI tile intersection
+2023-06-07 11:42:35,862: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-07 11:42:35,862: INFO: These tiles are  :
+2023-06-07 11:42:35,863: INFO:   1 : 36NXG
+2023-06-07 11:42:35,864: INFO:   2 : 36NYG
+2023-06-07 11:42:35,864: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-07 11:42:35,884: INFO: Finished ROI tile intersection
+2023-06-07 11:42:35,886: INFO: ---------------------------------------------------------------
+2023-06-07 11:42:35,887: INFO: Starting acd_integrated_raster():
+2023-06-07 11:42:35,888: INFO: ---------------------------------------------------------------
+2023-06-07 11:42:35,901: INFO: Starting ACD Raster Processes for Tile :  36NXG
+2023-06-07 11:50:09,870: INFO: ---------------------------------------------------------------
+2023-06-07 11:50:09,870: INFO:                     ****PROCESSING START****
+2023-06-07 11:50:09,873: INFO: ---------------------------------------------------------------
+2023-06-07 11:50:09,874: INFO: C:\Users\ir81\.conda\envs\pyeo_env_pcwe
+2023-06-07 11:50:09,875: INFO: True
+2023-06-07 11:50:09,876: INFO: ---------------------------------------------------------------
+2023-06-07 11:50:09,877: INFO: ---                  INTEGRATED PROCESSING START            ---
+2023-06-07 11:50:09,886: INFO: ---------------------------------------------------------------
+2023-06-07 11:50:09,886: INFO: Reading in parameters defined in: pyeo_windows.ini
+2023-06-07 11:50:09,886: INFO: ---------------------------------------------------------------
+2023-06-07 11:50:09,890: INFO: ---------------------------------------------------------------
+2023-06-07 11:50:09,891: INFO: Starting acd_config_to_log()
+2023-06-07 11:50:09,891: INFO: ---------------------------------------------------------------
+2023-06-07 11:50:09,892: INFO: Options:
+2023-06-07 11:50:09,892: INFO:   --dev Running in development mode, choosing development versions of functions where available
+2023-06-07 11:50:09,893: INFO:   -do_tile_intersection
+2023-06-07 11:50:09,893: INFO:       Sentinel-2 tile intersection with ROI enabled
+2023-06-07 11:50:09,894: INFO:   --do_raster
+2023-06-07 11:50:09,894: INFO:       raster pipeline enabled
+2023-06-07 11:50:09,894: INFO:   --download for change detection images
+2023-06-07 11:50:09,895: INFO:   --download_source = scihub
+2023-06-07 11:50:09,895: INFO:   Faulty Granule Threshold  : 350
+2023-06-07 11:50:09,895: INFO:   --do_delete_existing_vector , when vectorising the change report rasters, 
+2023-06-07 11:50:09,896: INFO:             existing vectors files will be deleted and new vector files created.
+2023-06-07 11:50:09,896: INFO: EPSG used is: 21097
+2023-06-07 11:50:09,896: INFO: List of image bands: ['B02', 'B03', 'B04', 'B08']
+2023-06-07 11:50:09,897: INFO: Model used: .\models\model_36MYE_Unoptimised_20230505_no_haze.pkl
+2023-06-07 11:50:09,897: INFO: 
+2023-06-07 11:50:09,897: INFO: List of class labels:
+2023-06-07 11:50:09,898: INFO:   1 : primary forest
+2023-06-07 11:50:09,898: INFO:   2 : plantation forest
+2023-06-07 11:50:09,899: INFO:   3 : bare soil
+2023-06-07 11:50:09,899: INFO:   4 : crops
+2023-06-07 11:50:09,899: INFO:   5 : grassland
+2023-06-07 11:50:09,900: INFO:   6 : open water
+2023-06-07 11:50:09,900: INFO:   7 : burn scar
+2023-06-07 11:50:09,900: INFO:   8 : cloud
+2023-06-07 11:50:09,901: INFO:   9 : cloud shadow
+2023-06-07 11:50:09,901: INFO:   10 : haze
+2023-06-07 11:50:09,902: INFO:   11 : sparse woodland
+2023-06-07 11:50:09,902: INFO:   12 : dense woodland
+2023-06-07 11:50:09,902: INFO:   13 : artificial
+2023-06-07 11:50:09,908: INFO: Detecting changes from any of the classes: [1, 2]
+2023-06-07 11:50:09,909: INFO:                     to any of the classes: [3]
+2023-06-07 11:50:09,909: INFO: ------------------------------------------------------------
+2023-06-07 11:50:09,910: INFO: Reporting Directories and Filepaths
+2023-06-07 11:50:09,910: INFO: Tile Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\data_folder
+2023-06-07 11:50:09,910: INFO: Working Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\pyeo_1
+2023-06-07 11:50:09,911: INFO: The following directories are relative to the working directory, i.e. stored underneath:
+2023-06-07 11:50:09,911: INFO: Integrated Directory is   : .\integrated
+2023-06-07 11:50:09,911: INFO: ROI Directory is   : .\roi
+2023-06-07 11:50:09,912: INFO: Geometry Directory is   : .\geometry
+2023-06-07 11:50:09,912: INFO: Path to the Administrative Boundaries used in the Change Report Vectorisation   : .\geometry\gadm41_KEN_1.json
+2023-06-07 11:50:09,912: INFO: Path to Sen2Cor is   : C:\Users\ir81\Sen2Cor-02.11.00-win64\L2A_Process
+2023-06-07 11:50:09,912: INFO: The Conda Environment specified in .ini file is :  pyeo_env_pcwe
+2023-06-07 11:50:09,913: INFO: -------------------------------------------
+2023-06-07 11:50:09,913: INFO: -------------------------------------------
+2023-06-07 11:50:09,913: INFO: ---------------------------------------------------------------
+2023-06-07 11:50:09,914: INFO: Starting acd_roi_tile_intersection()
+2023-06-07 11:50:09,914: INFO: ---------------------------------------------------------------
+2023-06-07 11:50:10,494: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-07 11:50:10,495: INFO: These tiles are  :
+2023-06-07 11:50:10,496: INFO:   1 : 36NXG
+2023-06-07 11:50:10,496: INFO:   2 : 36NYG
+2023-06-07 11:50:10,497: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-07 11:50:10,507: INFO: Finished ROI tile intersection
+2023-06-07 11:50:10,634: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-07 11:50:10,635: INFO: These tiles are  :
+2023-06-07 11:50:10,636: INFO:   1 : 36NXG
+2023-06-07 11:50:10,636: INFO:   2 : 36NYG
+2023-06-07 11:50:10,636: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-07 11:50:10,652: INFO: Finished ROI tile intersection
+2023-06-07 11:50:10,654: INFO: ---------------------------------------------------------------
+2023-06-07 11:50:10,657: INFO: Starting acd_integrated_raster():
+2023-06-07 11:50:10,658: INFO: ---------------------------------------------------------------
+2023-06-07 11:50:10,668: INFO: Starting ACD Raster Processes for Tile :  36NXG
+2023-06-07 12:23:16,914: INFO: ---------------------------------------------------------------
+2023-06-07 12:23:16,915: INFO:                     ****PROCESSING START****
+2023-06-07 12:23:16,916: INFO: ---------------------------------------------------------------
+2023-06-07 12:23:16,917: INFO: C:\Users\ir81\.conda\envs\pyeo_env_pcwe
+2023-06-07 12:23:16,917: INFO: True
+2023-06-07 12:23:16,917: INFO: ---------------------------------------------------------------
+2023-06-07 12:23:16,918: INFO: ---                  INTEGRATED PROCESSING START            ---
+2023-06-07 12:23:16,918: INFO: ---------------------------------------------------------------
+2023-06-07 12:23:16,919: INFO: Reading in parameters defined in: pyeo_windows.ini
+2023-06-07 12:23:16,919: INFO: ---------------------------------------------------------------
+2023-06-07 12:23:16,919: INFO: ---------------------------------------------------------------
+2023-06-07 12:23:16,920: INFO: Starting acd_config_to_log()
+2023-06-07 12:23:16,920: INFO: ---------------------------------------------------------------
+2023-06-07 12:23:16,920: INFO: Options:
+2023-06-07 12:23:16,921: INFO:   --dev Running in development mode, choosing development versions of functions where available
+2023-06-07 12:23:16,921: INFO:   -do_tile_intersection
+2023-06-07 12:23:16,921: INFO:       Sentinel-2 tile intersection with ROI enabled
+2023-06-07 12:23:16,922: INFO:   --do_raster
+2023-06-07 12:23:16,922: INFO:       raster pipeline enabled
+2023-06-07 12:23:16,923: INFO:   --download for change detection images
+2023-06-07 12:23:16,923: INFO:   --download_source = scihub
+2023-06-07 12:23:16,924: INFO:   Faulty Granule Threshold  : 350
+2023-06-07 12:23:16,924: INFO:   --do_delete_existing_vector , when vectorising the change report rasters, 
+2023-06-07 12:23:16,925: INFO:             existing vectors files will be deleted and new vector files created.
+2023-06-07 12:23:16,925: INFO: EPSG used is: 21097
+2023-06-07 12:23:16,926: INFO: List of image bands: ['B02', 'B03', 'B04', 'B08']
+2023-06-07 12:23:16,926: INFO: Model used: .\models\model_36MYE_Unoptimised_20230505_no_haze.pkl
+2023-06-07 12:23:16,926: INFO: 
+2023-06-07 12:23:16,926: INFO: List of class labels:
+2023-06-07 12:23:16,931: INFO:   1 : primary forest
+2023-06-07 12:23:16,932: INFO:   2 : plantation forest
+2023-06-07 12:23:16,933: INFO:   3 : bare soil
+2023-06-07 12:23:16,933: INFO:   4 : crops
+2023-06-07 12:23:16,934: INFO:   5 : grassland
+2023-06-07 12:23:16,934: INFO:   6 : open water
+2023-06-07 12:23:16,935: INFO:   7 : burn scar
+2023-06-07 12:23:16,935: INFO:   8 : cloud
+2023-06-07 12:23:16,935: INFO:   9 : cloud shadow
+2023-06-07 12:23:16,936: INFO:   10 : haze
+2023-06-07 12:23:16,936: INFO:   11 : sparse woodland
+2023-06-07 12:23:16,936: INFO:   12 : dense woodland
+2023-06-07 12:23:16,937: INFO:   13 : artificial
+2023-06-07 12:23:16,937: INFO: Detecting changes from any of the classes: [1, 2]
+2023-06-07 12:23:16,937: INFO:                     to any of the classes: [3]
+2023-06-07 12:23:16,938: INFO: ------------------------------------------------------------
+2023-06-07 12:23:16,938: INFO: Reporting Directories and Filepaths
+2023-06-07 12:23:16,939: INFO: Tile Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\data_folder
+2023-06-07 12:23:16,939: INFO: Working Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\pyeo_1
+2023-06-07 12:23:16,939: INFO: The following directories are relative to the working directory, i.e. stored underneath:
+2023-06-07 12:23:16,939: INFO: Integrated Directory is   : .\integrated
+2023-06-07 12:23:16,940: INFO: ROI Directory is   : .\roi
+2023-06-07 12:23:16,940: INFO: Geometry Directory is   : .\geometry
+2023-06-07 12:23:16,940: INFO: Path to the Administrative Boundaries used in the Change Report Vectorisation   : .\geometry\gadm41_KEN_1.json
+2023-06-07 12:23:16,941: INFO: Path to Sen2Cor is   : C:\Users\ir81\Sen2Cor-02.11.00-win64\L2A_Process.bat
+2023-06-07 12:23:16,941: INFO: The Conda Environment specified in .ini file is :  pyeo_env_pcwe
+2023-06-07 12:23:16,941: INFO: -------------------------------------------
+2023-06-07 12:23:16,941: INFO: -------------------------------------------
+2023-06-07 12:23:16,947: INFO: ---------------------------------------------------------------
+2023-06-07 12:23:16,948: INFO: Starting acd_roi_tile_intersection()
+2023-06-07 12:23:16,948: INFO: ---------------------------------------------------------------
+2023-06-07 12:23:17,790: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-07 12:23:17,790: INFO: These tiles are  :
+2023-06-07 12:23:17,791: INFO:   1 : 36NXG
+2023-06-07 12:23:17,792: INFO:   2 : 36NYG
+2023-06-07 12:23:17,792: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-07 12:23:17,805: INFO: Finished ROI tile intersection
+2023-06-07 12:23:17,959: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-07 12:23:17,960: INFO: These tiles are  :
+2023-06-07 12:23:17,961: INFO:   1 : 36NXG
+2023-06-07 12:23:17,962: INFO:   2 : 36NYG
+2023-06-07 12:23:17,962: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-07 12:23:17,975: INFO: Finished ROI tile intersection
+2023-06-07 12:23:17,975: INFO: ---------------------------------------------------------------
+2023-06-07 12:23:17,977: INFO: Starting acd_integrated_raster():
+2023-06-07 12:23:17,977: INFO: ---------------------------------------------------------------
+2023-06-07 12:23:17,991: INFO: Starting ACD Raster Processes for Tile :  36NXG
+2023-06-07 14:05:58,018: INFO: Finished ACD Raster Processes for Tile :  36NXG
+2023-06-07 14:05:58,052: INFO: Starting ACD Raster Processes for Tile :  36NYG
+2023-06-07 15:55:30,497: INFO: Finished ACD Raster Processes for Tile :  36NYG
+2023-06-07 15:55:30,503: INFO: ---------------------------------------------------------------
+2023-06-07 15:55:30,504: INFO: ---                  INTEGRATED PROCESSING END              ---
+2023-06-07 15:55:30,504: INFO: ---------------------------------------------------------------
+2023-06-07 16:44:57,308: INFO: ---------------------------------------------------------------
+2023-06-07 16:44:57,309: INFO:                     ****PROCESSING START****
+2023-06-07 16:44:57,309: INFO: ---------------------------------------------------------------
+2023-06-07 16:44:57,310: INFO: C:\Users\ir81\.conda\envs\pyeo_env_pcwe
+2023-06-07 16:44:57,311: INFO: True
+2023-06-07 16:44:57,311: INFO: ---------------------------------------------------------------
+2023-06-07 16:44:57,311: INFO: ---                  INTEGRATED PROCESSING START            ---
+2023-06-07 16:44:57,311: INFO: ---------------------------------------------------------------
+2023-06-07 16:44:57,311: INFO: Reading in parameters defined in: pyeo_windows.ini
+2023-06-07 16:44:57,311: INFO: ---------------------------------------------------------------
+2023-06-07 16:44:57,312: INFO: ---------------------------------------------------------------
+2023-06-07 16:44:57,313: INFO: Starting acd_config_to_log()
+2023-06-07 16:44:57,313: INFO: ---------------------------------------------------------------
+2023-06-07 16:44:57,313: INFO: Options:
+2023-06-07 16:44:57,313: INFO:   --dev Running in development mode, choosing development versions of functions where available
+2023-06-07 16:44:57,314: INFO:   -do_tile_intersection
+2023-06-07 16:44:57,314: INFO:       Sentinel-2 tile intersection with ROI enabled
+2023-06-07 16:44:57,314: INFO:   --do_raster
+2023-06-07 16:44:57,314: INFO:       raster pipeline enabled
+2023-06-07 16:44:57,314: INFO:   --classify to apply the random forest model and create classification layers
+2023-06-07 16:44:57,315: INFO:   --change to produce change detection layers and report images
+2023-06-07 16:44:57,315: INFO:          change start date  : 20220101
+2023-06-07 16:44:57,315: INFO:          change end date  : 20221231
+2023-06-07 16:44:57,315: INFO:   --do_delete_existing_vector , when vectorising the change report rasters, 
+2023-06-07 16:44:57,315: INFO:             existing vectors files will be deleted and new vector files created.
+2023-06-07 16:44:57,316: INFO: EPSG used is: 21097
+2023-06-07 16:44:57,316: INFO: List of image bands: ['B02', 'B03', 'B04', 'B08']
+2023-06-07 16:44:57,316: INFO: Model used: .\models\model_36MYE_Unoptimised_20230505_no_haze.pkl
+2023-06-07 16:44:57,317: INFO: 
+2023-06-07 16:44:57,317: INFO: List of class labels:
+2023-06-07 16:44:57,318: INFO:   1 : primary forest
+2023-06-07 16:44:57,318: INFO:   2 : plantation forest
+2023-06-07 16:44:57,318: INFO:   3 : bare soil
+2023-06-07 16:44:57,318: INFO:   4 : crops
+2023-06-07 16:44:57,318: INFO:   5 : grassland
+2023-06-07 16:44:57,318: INFO:   6 : open water
+2023-06-07 16:44:57,319: INFO:   7 : burn scar
+2023-06-07 16:44:57,319: INFO:   8 : cloud
+2023-06-07 16:44:57,319: INFO:   9 : cloud shadow
+2023-06-07 16:44:57,319: INFO:   10 : haze
+2023-06-07 16:44:57,319: INFO:   11 : sparse woodland
+2023-06-07 16:44:57,320: INFO:   12 : dense woodland
+2023-06-07 16:44:57,320: INFO:   13 : artificial
+2023-06-07 16:44:57,321: INFO: Detecting changes from any of the classes: [1, 2]
+2023-06-07 16:44:57,321: INFO:                     to any of the classes: [3]
+2023-06-07 16:44:57,321: INFO: ------------------------------------------------------------
+2023-06-07 16:44:57,321: INFO: Reporting Directories and Filepaths
+2023-06-07 16:44:57,321: INFO: Tile Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\data_folder
+2023-06-07 16:44:57,322: INFO: Working Directory is   : C:\Users\ir81\20230602_pyeo_test_installation\pyeo_1
+2023-06-07 16:44:57,322: INFO: The following directories are relative to the working directory, i.e. stored underneath:
+2023-06-07 16:44:57,322: INFO: Integrated Directory is   : .\integrated
+2023-06-07 16:44:57,322: INFO: ROI Directory is   : .\roi
+2023-06-07 16:44:57,322: INFO: Geometry Directory is   : .\geometry
+2023-06-07 16:44:57,323: INFO: Path to the Administrative Boundaries used in the Change Report Vectorisation   : .\geometry\gadm41_KEN_1.json
+2023-06-07 16:44:57,323: INFO: Path to Sen2Cor is   : C:\Users\ir81\Sen2Cor-02.11.00-win64\L2A_Process.bat
+2023-06-07 16:44:57,323: INFO: The Conda Environment specified in .ini file is :  pyeo_env_pcwe
+2023-06-07 16:44:57,323: INFO: -------------------------------------------
+2023-06-07 16:44:57,324: INFO: -------------------------------------------
+2023-06-07 16:44:57,324: INFO: ---------------------------------------------------------------
+2023-06-07 16:44:57,325: INFO: Starting acd_roi_tile_intersection()
+2023-06-07 16:44:57,325: INFO: ---------------------------------------------------------------
+2023-06-07 16:44:58,210: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-07 16:44:58,210: INFO: These tiles are  :
+2023-06-07 16:44:58,211: INFO:   1 : 36NXG
+2023-06-07 16:44:58,211: INFO:   2 : 36NYG
+2023-06-07 16:44:58,212: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-07 16:44:58,222: INFO: Finished ROI tile intersection
+2023-06-07 16:44:58,305: INFO: The provided ROI intersects with 2 Sentinel-2 tiles
+2023-06-07 16:44:58,305: INFO: These tiles are  :
+2023-06-07 16:44:58,306: INFO:   1 : 36NXG
+2023-06-07 16:44:58,307: INFO:   2 : 36NYG
+2023-06-07 16:44:58,308: INFO: Writing Sentinel-2 tiles that intersect with the provided ROI to  : .\roi\tilelist.csv
+2023-06-07 16:44:58,323: INFO: Finished ROI tile intersection
+2023-06-07 16:44:58,324: INFO: ---------------------------------------------------------------
+2023-06-07 16:44:58,325: INFO: Starting acd_integrated_raster():
+2023-06-07 16:44:58,326: INFO: ---------------------------------------------------------------
+2023-06-07 16:44:58,336: INFO: Starting ACD Raster Processes for Tile :  36NXG

--- a/pyeo_1/apps/acd_national/acd_by_tile_raster.py
+++ b/pyeo_1/apps/acd_national/acd_by_tile_raster.py
@@ -152,6 +152,29 @@ def acd_by_tile_raster(config_path: str,
     # Step 1: Create an initial cloud-free median composite from Sentinel-2 as a baseline map
     # ------------------------------------------------------------------------
 
+    if download_source == "dataspace":
+
+        tile_log.info(f'Running download handler for {download_source}')
+
+        credentials_dict["sent_2"] = {}
+        credentials_dict["sent_2"]["user"] = conf["dataspace"]["user"]
+        credentials_dict["sent_2"]["pass"] = conf["dataspace"]["pass"]
+        sen_user = credentials_dict["sent_2"]["user"]
+        sen_pass = credentials_dict["sent_2"]["pass"]
+
+    if download_source == "scihub":
+
+        tile_log.info(f'Running download handler for {download_source}')
+
+        credentials_dict["sent_2"] = {}
+        credentials_dict["sent_2"]["user"] = conf["sent_2"]["user"]
+        credentials_dict["sent_2"]["pass"] = conf["sent_2"]["pass"]
+        sen_user = credentials_dict["sent_2"]["user"]
+        sen_pass = credentials_dict["sent_2"]["pass"]
+
+        tile_log.info(f'credentials_dict: {credentials_dict}')
+
+
     if config_dict["build_composite"] or config_dict["do_all"]:
         tile_log.info("---------------------------------------------------------------")
         tile_log.info(
@@ -162,13 +185,13 @@ def acd_by_tile_raster(config_path: str,
 
         if download_source == "dataspace":
 
-            tile_log.info(f'Running download handler for {download_source}')
+        #     tile_log.info(f'Running download handler for {download_source}')
 
-            credentials_dict["sent_2"] = {}
-            credentials_dict["sent_2"]["user"] = conf["dataspace"]["user"]
-            credentials_dict["sent_2"]["pass"] = conf["dataspace"]["pass"]
-            sen_user = credentials_dict["sent_2"]["user"]
-            sen_pass = credentials_dict["sent_2"]["pass"]
+        #     credentials_dict["sent_2"] = {}
+        #     credentials_dict["sent_2"]["user"] = conf["dataspace"]["user"]
+        #     credentials_dict["sent_2"]["pass"] = conf["dataspace"]["pass"]
+        #     sen_user = credentials_dict["sent_2"]["user"]
+        #     sen_pass = credentials_dict["sent_2"]["pass"]
 
             try:
                 tiles_geom_path = "/data/clcr/shared/IMPRESS/matt/pyeo_1/pyeo_1_production/pyeo_1_production/geometry/kenya_s2_tiles.shp"
@@ -224,15 +247,15 @@ def acd_by_tile_raster(config_path: str,
 
         if download_source == "scihub":
 
-            tile_log.info(f'Running download handler for {download_source}')
+        #     tile_log.info(f'Running download handler for {download_source}')
 
-            credentials_dict["sent_2"] = {}
-            credentials_dict["sent_2"]["user"] = conf["sent_2"]["user"]
-            credentials_dict["sent_2"]["pass"] = conf["sent_2"]["pass"]
-            sen_user = credentials_dict["sent_2"]["user"]
-            sen_pass = credentials_dict["sent_2"]["pass"]
+        #     credentials_dict["sent_2"] = {}
+        #     credentials_dict["sent_2"]["user"] = conf["sent_2"]["user"]
+        #     credentials_dict["sent_2"]["pass"] = conf["sent_2"]["pass"]
+        #     sen_user = credentials_dict["sent_2"]["user"]
+        #     sen_pass = credentials_dict["sent_2"]["pass"]
 
-            tile_log.info(f'credentials_dict: {credentials_dict}')
+        #     tile_log.info(f'credentials_dict: {credentials_dict}')
 
             try:
                 composite_products_all = queries_and_downloads.check_for_s2_data_by_date(
@@ -266,219 +289,186 @@ def acd_by_tile_raster(config_path: str,
             )
             tile_log.info(f'df_all: {df_all.head()}')
 
-    # here the main call (from if download_source == "scihub" branch) is resumed
-    df = df_all.query("size >= " + str(faulty_granule_threshold))
+        # here the main call (from if download_source == "scihub" branch) is resumed
+        df = df_all.query("size >= " + str(faulty_granule_threshold))
 
-    tile_log.info(
-        "Removed {} faulty scenes <{}MB in size from the list:".format(
-            len(df_all) - len(df), faulty_granule_threshold
-        )
-    )
-    # find < threshold sizes, report to log
-    df_faulty = df_all.query("size < " + str(faulty_granule_threshold))
-    for r in range(len(df_faulty)):
         tile_log.info(
-            "   {} MB: {}".format(
-                df_faulty.iloc[r, :]["size"], df_faulty.iloc[r, :]["title"]
+            "Removed {} faulty scenes <{}MB in size from the list:".format(
+                len(df_all) - len(df), faulty_granule_threshold
             )
         )
-
-    l1c_products = df[df.processinglevel == "Level-1C"]
-    l2a_products = df[df.processinglevel == "Level-2A"]
-    tile_log.info("    {} L1C products".format(l1c_products.shape[0]))
-    tile_log.info("    {} L2A products".format(l2a_products.shape[0]))
-
-    
-    rel_orbits = np.unique(l1c_products["relativeorbitnumber"])
-    if len(rel_orbits) > 0:
-        if l1c_products.shape[0] > max_image_number / len(rel_orbits):
+        # find < threshold sizes, report to log
+        df_faulty = df_all.query("size < " + str(faulty_granule_threshold))
+        for r in range(len(df_faulty)):
             tile_log.info(
-                "Capping the number of L1C products to {}".format(max_image_number)
-            )
-            tile_log.info(
-                "Relative orbits found covering tile: {}".format(rel_orbits)
-            )
-            uuids = []
-            for orb in rel_orbits:
-                uuids = uuids + list(
-                    l1c_products.loc[
-                        l1c_products["relativeorbitnumber"] == orb
-                    ].sort_values(by=["cloudcoverpercentage"], ascending=True)[
-                        "uuid"
-                    ][
-                        : int(max_image_number / len(rel_orbits))
-                    ]
+                "   {} MB: {}".format(
+                    df_faulty.iloc[r, :]["size"], df_faulty.iloc[r, :]["title"]
                 )
-            # keeps least cloudy n (max image number)
-            l1c_products = l1c_products[l1c_products["uuid"].isin(uuids)]
-            tile_log.info(
-                "    {} L1C products remain:".format(l1c_products.shape[0])
             )
-            for product in l1c_products["title"]:
-                tile_log.info("       {}".format(product))
 
-
-    rel_orbits = np.unique(l2a_products["relativeorbitnumber"])
-    if len(rel_orbits) > 0:
-        if l2a_products.shape[0] > max_image_number / len(rel_orbits):
-            tile_log.info(
-                "Capping the number of L2A products to {}".format(max_image_number)
-            )
-            tile_log.info(
-                "Relative orbits found covering tile: {}".format(rel_orbits)
-            )
-            uuids = []
-            for orb in rel_orbits:
-                uuids = uuids + list(
-                    l2a_products.loc[
-                        l2a_products["relativeorbitnumber"] == orb
-                    ].sort_values(by=["cloudcoverpercentage"], ascending=True)[
-                        "uuid"
-                    ][
-                        : int(max_image_number / len(rel_orbits))
-                    ]
-                )
-            l2a_products = l2a_products[l2a_products["uuid"].isin(uuids)]
-            tile_log.info(
-                "    {} L2A products remain:".format(l2a_products.shape[0])
-            )
-            for product in l2a_products["title"]:
-                tile_log.info("       {}".format(product))
-
-
-    if l1c_products.shape[0] > 0 and l2a_products.shape[0] > 0:
-        tile_log.info(
-            "Filtering out L1C products that have the same 'beginposition' time stamp as an existing L2A product."
-        )
-        (
-            l1c_products,
-            l2a_products,
-        ) = queries_and_downloads.filter_unique_l1c_and_l2a_data(df)
-        tile_log.info(
-            "--> {} L1C and L2A products with unique 'beginposition' time stamp for the composite:".format(
-                l1c_products.shape[0] + l2a_products.shape[0]
-            )
-        )
+        l1c_products = df[df.processinglevel == "Level-1C"]
+        l2a_products = df[df.processinglevel == "Level-2A"]
         tile_log.info("    {} L1C products".format(l1c_products.shape[0]))
         tile_log.info("    {} L2A products".format(l2a_products.shape[0]))
-    df = None
 
-    
-    # Search the local directories, composite/L2A and L1C, checking if scenes have already been downloaded and/or processed whilst checking their dir sizes
-    if download_source == "scihub":
-        if l1c_products.shape[0] > 0:
+        
+        rel_orbits = np.unique(l1c_products["relativeorbitnumber"])
+        if len(rel_orbits) > 0:
+            if l1c_products.shape[0] > max_image_number / len(rel_orbits):
+                tile_log.info(
+                    "Capping the number of L1C products to {}".format(max_image_number)
+                )
+                tile_log.info(
+                    "Relative orbits found covering tile: {}".format(rel_orbits)
+                )
+                uuids = []
+                for orb in rel_orbits:
+                    uuids = uuids + list(
+                        l1c_products.loc[
+                            l1c_products["relativeorbitnumber"] == orb
+                        ].sort_values(by=["cloudcoverpercentage"], ascending=True)[
+                            "uuid"
+                        ][
+                            : int(max_image_number / len(rel_orbits))
+                        ]
+                    )
+                # keeps least cloudy n (max image number)
+                l1c_products = l1c_products[l1c_products["uuid"].isin(uuids)]
+                tile_log.info(
+                    "    {} L1C products remain:".format(l1c_products.shape[0])
+                )
+                for product in l1c_products["title"]:
+                    tile_log.info("       {}".format(product))
+
+
+        rel_orbits = np.unique(l2a_products["relativeorbitnumber"])
+        if len(rel_orbits) > 0:
+            if l2a_products.shape[0] > max_image_number / len(rel_orbits):
+                tile_log.info(
+                    "Capping the number of L2A products to {}".format(max_image_number)
+                )
+                tile_log.info(
+                    "Relative orbits found covering tile: {}".format(rel_orbits)
+                )
+                uuids = []
+                for orb in rel_orbits:
+                    uuids = uuids + list(
+                        l2a_products.loc[
+                            l2a_products["relativeorbitnumber"] == orb
+                        ].sort_values(by=["cloudcoverpercentage"], ascending=True)[
+                            "uuid"
+                        ][
+                            : int(max_image_number / len(rel_orbits))
+                        ]
+                    )
+                l2a_products = l2a_products[l2a_products["uuid"].isin(uuids)]
+                tile_log.info(
+                    "    {} L2A products remain:".format(l2a_products.shape[0])
+                )
+                for product in l2a_products["title"]:
+                    tile_log.info("       {}".format(product))
+
+
+        if l1c_products.shape[0] > 0 and l2a_products.shape[0] > 0:
             tile_log.info(
-                "Checking for already downloaded and zipped L1C or L2A products and"
+                "Filtering out L1C products that have the same 'beginposition' time stamp as an existing L2A product."
             )
-            tile_log.info("  availability of matching L2A products for download.")
-            n = len(l1c_products)
-            drop = []
-            add = []
-            for r in range(n):
-                id = l1c_products.iloc[r, :]["title"]
-                search_term = (
-                    id.split("_")[2]
-                    + "_"
-                    + id.split("_")[3]
-                    + "_"
-                    + id.split("_")[4]
-                    + "_"
-                    + id.split("_")[5]
+            (
+                l1c_products,
+                l2a_products,
+            ) = queries_and_downloads.filter_unique_l1c_and_l2a_data(df)
+            tile_log.info(
+                "--> {} L1C and L2A products with unique 'beginposition' time stamp for the composite:".format(
+                    l1c_products.shape[0] + l2a_products.shape[0]
                 )
-                tile_log.info(
-                    "Searching locally for file names containing: {}.".format(
-                        search_term
-                    )
-                )
-                file_list = (
-                    [
-                        os.path.join(composite_l1_image_dir, f)
-                        for f in os.listdir(composite_l1_image_dir)
-                    ]
-                    + [
-                        os.path.join(composite_l2_image_dir, f)
-                        for f in os.listdir(composite_l2_image_dir)
-                    ]
-                    + [
-                        os.path.join(composite_l2_masked_image_dir, f)
-                        for f in os.listdir(composite_l2_masked_image_dir)
-                    ]
-                )
-                for f in file_list:
-                    if search_term in f:
-                        tile_log.info("  Product already downloaded: {}".format(f))
-                        drop.append(l1c_products.index[r])
-                search_term = (
-                    "*"
-                    + id.split("_")[2]
-                    + "_"
-                    + id.split("_")[3]
-                    + "_"
-                    + id.split("_")[4]
-                    + "_"
-                    + id.split("_")[5]
-                    + "*"
-                )
+            )
+            tile_log.info("    {} L1C products".format(l1c_products.shape[0]))
+            tile_log.info("    {} L2A products".format(l2a_products.shape[0]))
+        df = None
 
-
+        
+        # Search the local directories, composite/L2A and L1C, checking if scenes have already been downloaded and/or processed whilst checking their dir sizes
+        if download_source == "scihub":
+            if l1c_products.shape[0] > 0:
                 tile_log.info(
-                    "Searching on the data hub for files containing: {}.".format(
-                        search_term
+                    "Checking for already downloaded and zipped L1C or L2A products and"
+                )
+                tile_log.info("  availability of matching L2A products for download.")
+                n = len(l1c_products)
+                drop = []
+                add = []
+                for r in range(n):
+                    id = l1c_products.iloc[r, :]["title"]
+                    search_term = (
+                        id.split("_")[2]
+                        + "_"
+                        + id.split("_")[3]
+                        + "_"
+                        + id.split("_")[4]
+                        + "_"
+                        + id.split("_")[5]
                     )
-                )
-                matching_l2a_products = queries_and_downloads._file_api_query(
-                    user=sen_user,
-                    passwd=sen_pass,
-                    start_date=composite_start_date,
-                    end_date=composite_end_date,
-                    filename=search_term,
-                    cloud=cloud_cover,
-                    producttype="S2MSI2A",
-                )
-                    
-                matching_l2a_products_df = pd.DataFrame.from_dict(
-                    matching_l2a_products, orient="index"
-                )
-                # 07/03/2023: Matt - Applied Ali's fix for converting product size to MB to compare against faulty_grandule_threshold
-                if (
-                    len(matching_l2a_products_df) == 1
-                    and [
-                        float(x[0]) * {"GB": 1e3, "MB": 1, "KB": 1e-3}[x[1]]
-                        for x in [matching_l2a_products_df["size"][0].split(" ")]
-                    ][0]
-                    > faulty_granule_threshold
-                ):
-                    tile_log.info("Replacing L1C {} with L2A product:".format(id))
                     tile_log.info(
-                        "              {}".format(
-                            matching_l2a_products_df.iloc[0, :]["title"]
+                        "Searching locally for file names containing: {}.".format(
+                            search_term
                         )
+                    )
+                    file_list = (
+                        [
+                            os.path.join(composite_l1_image_dir, f)
+                            for f in os.listdir(composite_l1_image_dir)
+                        ]
+                        + [
+                            os.path.join(composite_l2_image_dir, f)
+                            for f in os.listdir(composite_l2_image_dir)
+                        ]
+                        + [
+                            os.path.join(composite_l2_masked_image_dir, f)
+                            for f in os.listdir(composite_l2_masked_image_dir)
+                        ]
+                    )
+                    for f in file_list:
+                        if search_term in f:
+                            tile_log.info("  Product already downloaded: {}".format(f))
+                            drop.append(l1c_products.index[r])
+                    search_term = (
+                        "*"
+                        + id.split("_")[2]
+                        + "_"
+                        + id.split("_")[3]
+                        + "_"
+                        + id.split("_")[4]
+                        + "_"
+                        + id.split("_")[5]
+                        + "*"
                     )
 
-                    drop.append(l1c_products.index[r])
-                    add.append(matching_l2a_products_df.iloc[0, :])
-                if len(matching_l2a_products_df) == 0:
-                    pass
-                if len(matching_l2a_products_df) > 1:
-                    # check granule sizes on the server
-                    matching_l2a_products_df["size"] = (
-                        matching_l2a_products_df["size"]
-                        .str.split(" ")
-                        .apply(
-                            lambda x: float(x[0])
-                            * {"GB": 1e3, "MB": 1, "KB": 1e-3}[x[1]]
+
+                    tile_log.info(
+                        "Searching on the data hub for files containing: {}.".format(
+                            search_term
                         )
                     )
-                    matching_l2a_products_df = matching_l2a_products_df.query(
-                        "size >= " + str(faulty_granule_threshold)
+                    matching_l2a_products = queries_and_downloads._file_api_query(
+                        user=sen_user,
+                        passwd=sen_pass,
+                        start_date=composite_start_date,
+                        end_date=composite_end_date,
+                        filename=search_term,
+                        cloud=cloud_cover,
+                        producttype="S2MSI2A",
                     )
+                        
+                    matching_l2a_products_df = pd.DataFrame.from_dict(
+                        matching_l2a_products, orient="index"
+                    )
+                    # 07/03/2023: Matt - Applied Ali's fix for converting product size to MB to compare against faulty_grandule_threshold
                     if (
-                        matching_l2a_products_df.iloc[0, :]["size"]
-                        .str.split(" ")
-                        .apply(
-                            lambda x: float(x[0])
-                            * {"GB": 1e3, "MB": 1, "KB": 1e-3}[x[1]]
-                        )
+                        len(matching_l2a_products_df) == 1
+                        and [
+                            float(x[0]) * {"GB": 1e3, "MB": 1, "KB": 1e-3}[x[1]]
+                            for x in [matching_l2a_products_df["size"][0].split(" ")]
+                        ][0]
                         > faulty_granule_threshold
                     ):
                         tile_log.info("Replacing L1C {} with L2A product:".format(id))
@@ -487,322 +477,270 @@ def acd_by_tile_raster(config_path: str,
                                 matching_l2a_products_df.iloc[0, :]["title"]
                             )
                         )
+
                         drop.append(l1c_products.index[r])
                         add.append(matching_l2a_products_df.iloc[0, :])
-            if len(drop) > 0:
-                l1c_products = l1c_products.drop(index=drop)
-            if len(add) > 0:
-                # l2a_products = l2a_products.append(add)
-                add = pd.DataFrame(add)
-                l2a_products = pd.concat([l2a_products, add])
+                    if len(matching_l2a_products_df) == 0:
+                        pass
+                    if len(matching_l2a_products_df) > 1:
+                        # check granule sizes on the server
+                        matching_l2a_products_df["size"] = (
+                            matching_l2a_products_df["size"]
+                            .str.split(" ")
+                            .apply(
+                                lambda x: float(x[0])
+                                * {"GB": 1e3, "MB": 1, "KB": 1e-3}[x[1]]
+                            )
+                        )
+                        matching_l2a_products_df = matching_l2a_products_df.query(
+                            "size >= " + str(faulty_granule_threshold)
+                        )
+                        if (
+                            matching_l2a_products_df.iloc[0, :]["size"]
+                            .str.split(" ")
+                            .apply(
+                                lambda x: float(x[0])
+                                * {"GB": 1e3, "MB": 1, "KB": 1e-3}[x[1]]
+                            )
+                            > faulty_granule_threshold
+                        ):
+                            tile_log.info("Replacing L1C {} with L2A product:".format(id))
+                            tile_log.info(
+                                "              {}".format(
+                                    matching_l2a_products_df.iloc[0, :]["title"]
+                                )
+                            )
+                            drop.append(l1c_products.index[r])
+                            add.append(matching_l2a_products_df.iloc[0, :])
+                if len(drop) > 0:
+                    l1c_products = l1c_products.drop(index=drop)
+                if len(add) > 0:
+                    # l2a_products = l2a_products.append(add)
+                    add = pd.DataFrame(add)
+                    l2a_products = pd.concat([l2a_products, add])
 
-    # here, dataspace and scihub derived l1c_products and l2a_products lists are the "same"
-    l2a_products = l2a_products.drop_duplicates(subset="title")
-    tile_log.info(
-        "    {} L1C products remaining for download".format(
-            l1c_products.shape[0]
-        )
-    )
-    tile_log.info(
-        "    {} L2A products remaining for download".format(
-            l2a_products.shape[0]
-        )
-    )
-
-    ######### above is querying
-
-    ######## below is downloading
-    # if L1C products remain after matching for L2As, then download the unmatched L1Cs
-    if l1c_products.shape[0] > 0:
-        tile_log.info(f"Downloading Sentinel-2 L1C products from {download_source}:")
-
-        if download_source == "scihub":
-
-            queries_and_downloads.download_s2_data_from_df(
-                l1c_products,
-                composite_l1_image_dir,
-                composite_l2_image_dir,
-                source="scihub",
-                user=sen_user,
-                passwd=sen_pass,
-                try_scihub_on_fail=True,
+        # here, dataspace and scihub derived l1c_products and l2a_products lists are the "same"
+        l2a_products = l2a_products.drop_duplicates(subset="title")
+        tile_log.info(
+            "    {} L1C products remaining for download".format(
+                l1c_products.shape[0]
             )
-
-        if download_source == "dataspace":
-
-            queries_and_downloads.download_s2_data_from_dataspace(
-                product_df=l1c_products,
-                l1c_directory=composite_l1_image_dir,
-                l2a_directory=composite_l2_image_dir,
-                dataspace_username=sen_user,
-                dataspace_password=sen_pass,
-                log=tile_log
+        )
+        tile_log.info(
+            "    {} L2A products remaining for download".format(
+                l2a_products.shape[0]
             )
-        
-        tile_log.info("Atmospheric correction with sen2cor.")
-        raster_manipulation.atmospheric_correction(
-            composite_l1_image_dir,
-            composite_l2_image_dir,
-            sen2cor_path,
-            delete_unprocessed_image=False,
-            log=tile_log,
         )
 
-    if l2a_products.shape[0] > 0:
-        tile_log.info("Downloading Sentinel-2 L2A products.")
+        ######### above is querying
 
-        if download_source == "scihub":
+        ######## below is downloading
+        # if L1C products remain after matching for L2As, then download the unmatched L1Cs
+        if l1c_products.shape[0] > 0:
+            tile_log.info(f"Downloading Sentinel-2 L1C products from {download_source}:")
 
-            queries_and_downloads.download_s2_data(
-                l2a_products.to_dict("index"),
-                composite_l1_image_dir,
-                composite_l2_image_dir,
-                source="scihub",
-                # download_source,
-                user=sen_user,
-                passwd=sen_pass,
-                try_scihub_on_fail=True,
-            )
-        if download_source == "dataspace":
+            if download_source == "scihub":
+
+                queries_and_downloads.download_s2_data_from_df(
+                    l1c_products,
+                    composite_l1_image_dir,
+                    composite_l2_image_dir,
+                    source="scihub",
+                    user=sen_user,
+                    passwd=sen_pass,
+                    try_scihub_on_fail=True,
+                )
+
+            if download_source == "dataspace":
+
+                queries_and_downloads.download_s2_data_from_dataspace(
+                    product_df=l1c_products,
+                    l1c_directory=composite_l1_image_dir,
+                    l2a_directory=composite_l2_image_dir,
+                    dataspace_username=sen_user,
+                    dataspace_password=sen_pass,
+                    log=tile_log
+                )
             
-            queries_and_downloads.download_s2_data_from_dataspace(
-                product_df=l2a_products,
-                l1c_directory=composite_l1_image_dir,
-                l2a_directory=composite_l2_image_dir,
-                dataspace_username=sen_user,
-                dataspace_password=sen_pass,
-                log=tile_log
+            tile_log.info("Atmospheric correction with sen2cor.")
+            raster_manipulation.atmospheric_correction(
+                composite_l1_image_dir,
+                composite_l2_image_dir,
+                sen2cor_path,
+                delete_unprocessed_image=False,
+                log=tile_log,
             )
 
-    # check for incomplete L2A downloads
-    incomplete_downloads, sizes = raster_manipulation.find_small_safe_dirs(
-        composite_l2_image_dir, threshold=faulty_granule_threshold * 1024 * 1024
-    )
-    if len(incomplete_downloads) > 0:
-        for index, safe_dir in enumerate(incomplete_downloads):
-            if sizes[
-                index
-            ] / 1024 / 1024 < faulty_granule_threshold and os.path.exists(safe_dir):
-                tile_log.warning(
-                    "Found likely incomplete download of size {} MB: {}".format(
-                        str(round(sizes[index] / 1024 / 1024)), safe_dir
-                    )
+        if l2a_products.shape[0] > 0:
+            tile_log.info("Downloading Sentinel-2 L2A products.")
+
+            if download_source == "scihub":
+
+                queries_and_downloads.download_s2_data(
+                    l2a_products.to_dict("index"),
+                    composite_l1_image_dir,
+                    composite_l2_image_dir,
+                    source="scihub",
+                    # download_source,
+                    user=sen_user,
+                    passwd=sen_pass,
+                    try_scihub_on_fail=True,
                 )
-                # shutil.rmtree(safe_dir)
-
-    tile_log.info("---------------------------------------------------------------")
-    tile_log.info(
-        "Image download and atmospheric correction for composite is complete."
-    )
-    tile_log.info("---------------------------------------------------------------")
-
-    if config_dict["do_delete"]:
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-        tile_log.info(
-            "Deleting downloaded L1C images for composite, keeping only derived L2A products"
-        )
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-        directory = composite_l1_image_dir
-        tile_log.info("Deleting {}".format(directory))
-        shutil.rmtree(directory)
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-        tile_log.info("Deletion of L1C images complete. Keeping only L2A images.")
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-    else:
-        if config_dict["do_zip"]:
-            tile_log.info(
-                "---------------------------------------------------------------"
-            )
-            tile_log.info(
-                "Zipping downloaded L1C images for composite after atmospheric correction"
-            )
-            tile_log.info(
-                "---------------------------------------------------------------"
-            )
-            filesystem_utilities.zip_contents(composite_l1_image_dir)
-            tile_log.info(
-                "---------------------------------------------------------------"
-            )
-            tile_log.info("Zipping complete")
-            tile_log.info(
-                "---------------------------------------------------------------"
-            )
-
-    tile_log.info("---------------------------------------------------------------")
-    tile_log.info(
-        "Applying simple cloud, cloud shadow and haze mask based on SCL files and stacking the masked band raster files."
-    )
-    tile_log.info("---------------------------------------------------------------")
-
-    directory = composite_l2_masked_image_dir
-    masked_file_paths = [
-        f
-        for f in os.listdir(directory)
-        if f.endswith(".tif") and os.path.isfile(os.path.join(directory, f))
-    ]
-
-    directory = composite_l2_image_dir
-    l2a_zip_file_paths = [f for f in os.listdir(directory) if f.endswith(".zip")]
-
-    if len(l2a_zip_file_paths) > 0:
-        for f in l2a_zip_file_paths:
-            # check whether the zipped file has already been cloud masked
-            zip_timestamp = filesystem_utilities.get_image_acquisition_time(
-                os.path.basename(f)
-            ).strftime("%Y%m%dT%H%M%S")
-            if any(zip_timestamp in f for f in masked_file_paths):
-                continue
-            else:
-                # extract it if not
-                filesystem_utilities.unzip_contents(
-                    os.path.join(composite_l2_image_dir, f),
-                    ifstartswith="S2",
-                    ending=".SAFE",
+            if download_source == "dataspace":
+                
+                queries_and_downloads.download_s2_data_from_dataspace(
+                    product_df=l2a_products,
+                    l1c_directory=composite_l1_image_dir,
+                    l2a_directory=composite_l2_image_dir,
+                    dataspace_username=sen_user,
+                    dataspace_password=sen_pass,
+                    log=tile_log
                 )
 
-    directory = composite_l2_image_dir
-    l2a_safe_file_paths = [
-        f
-        for f in os.listdir(directory)
-        if f.endswith(".SAFE") and os.path.isdir(os.path.join(directory, f))
-    ]
-
-    files_for_cloud_masking = []
-    if len(l2a_safe_file_paths) > 0:
-        for f in l2a_safe_file_paths:
-            # check whether the L2A SAFE file has already been cloud masked
-            safe_timestamp = filesystem_utilities.get_image_acquisition_time(
-                os.path.basename(f)
-            ).strftime("%Y%m%dT%H%M%S")
-            if any(safe_timestamp in f for f in masked_file_paths):
-                continue
-            else:
-                # add it to the list of files to do if it has not been cloud masked yet
-                files_for_cloud_masking = files_for_cloud_masking + [f]
-
-    if len(files_for_cloud_masking) == 0:
-        tile_log.info(
-            "No L2A images found for cloud masking. They may already have been done."
+        # check for incomplete L2A downloads
+        incomplete_downloads, sizes = raster_manipulation.find_small_safe_dirs(
+            composite_l2_image_dir, threshold=faulty_granule_threshold * 1024 * 1024
         )
-    else:
-        raster_manipulation.apply_scl_cloud_mask(
-            composite_l2_image_dir,
-            composite_l2_masked_image_dir,
-            scl_classes=[0, 1, 2, 3, 8, 9, 10, 11],
-            buffer_size=buffer_size_composite,
-            bands=bands,
-            out_resolution=out_resolution,
-            haze=None,
-            epsg=epsg,
-            skip_existing=skip_existing,
-        )
-    # I.R. 20220607 START
-    # Apply offset to any images of processing baseline 0400 in the composite cloud_masked folder
-    tile_log.info("---------------------------------------------------------------")
-    tile_log.info("Offsetting cloud masked L2A images for composite.")
-    tile_log.info("---------------------------------------------------------------")
-
-    raster_manipulation.apply_processing_baseline_offset_correction_to_tiff_file_directory(
-        composite_l2_masked_image_dir, composite_l2_masked_image_dir
-    )
-
-    tile_log.info("---------------------------------------------------------------")
-    tile_log.info("Offsetting of cloud masked L2A images for composite complete.")
-    tile_log.info("---------------------------------------------------------------")
-    # I.R. 20220607 END
-
-    if config_dict["do_quicklooks"] or config_dict["do_all"]:
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-        tile_log.info("Producing quicklooks.")
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-        dirs_for_quicklooks = [composite_l2_masked_image_dir]
-        for main_dir in dirs_for_quicklooks:
-            files = [
-                f.path
-                for f in os.scandir(main_dir)
-                if f.is_file() and os.path.basename(f).endswith(".tif")
-            ]
-            # files = [ f.path for f in os.scandir(main_dir) if f.is_file() and os.path.basename(f).endswith(".tif") and "class" in os.path.basename(f) ] # do classification images only
-            if len(files) == 0:
-                tile_log.warning("No images found in {}.".format(main_dir))
-            else:
-                for f in files:
-                    quicklook_path = os.path.join(
-                        quicklook_dir,
-                        os.path.basename(f).split(".")[0] + ".png",
+        if len(incomplete_downloads) > 0:
+            for index, safe_dir in enumerate(incomplete_downloads):
+                if sizes[
+                    index
+                ] / 1024 / 1024 < faulty_granule_threshold and os.path.exists(safe_dir):
+                    tile_log.warning(
+                        "Found likely incomplete download of size {} MB: {}".format(
+                            str(round(sizes[index] / 1024 / 1024)), safe_dir
+                        )
                     )
-                    tile_log.info("Creating quicklook: {}".format(quicklook_path))
-                    raster_manipulation.create_quicklook(
-                        f,
-                        quicklook_path,
-                        width=512,
-                        height=512,
-                        format="PNG",
-                        bands=[3, 2, 1],
-                        scale_factors=[[0, 2000, 0, 255]],
+                    # shutil.rmtree(safe_dir)
+
+        tile_log.info("---------------------------------------------------------------")
+        tile_log.info(
+            "Image download and atmospheric correction for composite is complete."
+        )
+        tile_log.info("---------------------------------------------------------------")
+
+        if config_dict["do_delete"]:
+            tile_log.info(
+                "---------------------------------------------------------------"
+            )
+            tile_log.info(
+                "Deleting downloaded L1C images for composite, keeping only derived L2A products"
+            )
+            tile_log.info(
+                "---------------------------------------------------------------"
+            )
+            directory = composite_l1_image_dir
+            tile_log.info("Deleting {}".format(directory))
+            shutil.rmtree(directory)
+            tile_log.info(
+                "---------------------------------------------------------------"
+            )
+            tile_log.info("Deletion of L1C images complete. Keeping only L2A images.")
+            tile_log.info(
+                "---------------------------------------------------------------"
+            )
+        else:
+            if config_dict["do_zip"]:
+                tile_log.info(
+                    "---------------------------------------------------------------"
+                )
+                tile_log.info(
+                    "Zipping downloaded L1C images for composite after atmospheric correction"
+                )
+                tile_log.info(
+                    "---------------------------------------------------------------"
+                )
+                filesystem_utilities.zip_contents(composite_l1_image_dir)
+                tile_log.info(
+                    "---------------------------------------------------------------"
+                )
+                tile_log.info("Zipping complete")
+                tile_log.info(
+                    "---------------------------------------------------------------"
+                )
+
+        tile_log.info("---------------------------------------------------------------")
+        tile_log.info(
+            "Applying simple cloud, cloud shadow and haze mask based on SCL files and stacking the masked band raster files."
+        )
+        tile_log.info("---------------------------------------------------------------")
+
+        directory = composite_l2_masked_image_dir
+        masked_file_paths = [
+            f
+            for f in os.listdir(directory)
+            if f.endswith(".tif") and os.path.isfile(os.path.join(directory, f))
+        ]
+
+        directory = composite_l2_image_dir
+        l2a_zip_file_paths = [f for f in os.listdir(directory) if f.endswith(".zip")]
+
+        if len(l2a_zip_file_paths) > 0:
+            for f in l2a_zip_file_paths:
+                # check whether the zipped file has already been cloud masked
+                zip_timestamp = filesystem_utilities.get_image_acquisition_time(
+                    os.path.basename(f)
+                ).strftime("%Y%m%dT%H%M%S")
+                if any(zip_timestamp in f for f in masked_file_paths):
+                    continue
+                else:
+                    # extract it if not
+                    filesystem_utilities.unzip_contents(
+                        os.path.join(composite_l2_image_dir, f),
+                        ifstartswith="S2",
+                        ending=".SAFE",
                     )
-    tile_log.info("Quicklooks complete.")
 
-    if config_dict["do_zip"]:
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-        tile_log.info(
-            "Zipping downloaded L2A images for composite after cloud masking and band stacking"
-        )
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-        filesystem_utilities.zip_contents(composite_l2_image_dir)
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-        tile_log.info("Zipping complete")
-        tile_log.info(
-            "---------------------------------------------------------------"
+        directory = composite_l2_image_dir
+        l2a_safe_file_paths = [
+            f
+            for f in os.listdir(directory)
+            if f.endswith(".SAFE") and os.path.isdir(os.path.join(directory, f))
+        ]
+
+        files_for_cloud_masking = []
+        if len(l2a_safe_file_paths) > 0:
+            for f in l2a_safe_file_paths:
+                # check whether the L2A SAFE file has already been cloud masked
+                safe_timestamp = filesystem_utilities.get_image_acquisition_time(
+                    os.path.basename(f)
+                ).strftime("%Y%m%dT%H%M%S")
+                if any(safe_timestamp in f for f in masked_file_paths):
+                    continue
+                else:
+                    # add it to the list of files to do if it has not been cloud masked yet
+                    files_for_cloud_masking = files_for_cloud_masking + [f]
+
+        if len(files_for_cloud_masking) == 0:
+            tile_log.info(
+                "No L2A images found for cloud masking. They may already have been done."
+            )
+        else:
+            raster_manipulation.apply_scl_cloud_mask(
+                composite_l2_image_dir,
+                composite_l2_masked_image_dir,
+                scl_classes=[0, 1, 2, 3, 8, 9, 10, 11],
+                buffer_size=buffer_size_composite,
+                bands=bands,
+                out_resolution=out_resolution,
+                haze=None,
+                epsg=epsg,
+                skip_existing=skip_existing,
+            )
+        # I.R. 20220607 START
+        # Apply offset to any images of processing baseline 0400 in the composite cloud_masked folder
+        tile_log.info("---------------------------------------------------------------")
+        tile_log.info("Offsetting cloud masked L2A images for composite.")
+        tile_log.info("---------------------------------------------------------------")
+
+        raster_manipulation.apply_processing_baseline_offset_correction_to_tiff_file_directory(
+            composite_l2_masked_image_dir, composite_l2_masked_image_dir
         )
 
-    tile_log.info("---------------------------------------------------------------")
-    tile_log.info(
-        "Building initial cloud-free median composite from directory {}".format(
-            composite_l2_masked_image_dir
-        )
-    )
-    tile_log.info("---------------------------------------------------------------")
-    directory = composite_l2_masked_image_dir
-    masked_file_paths = [
-        f
-        for f in os.listdir(directory)
-        if f.endswith(".tif") and os.path.isfile(os.path.join(directory, f))
-    ]
-
-    if len(masked_file_paths) > 0:
-        raster_manipulation.clever_composite_directory(
-            composite_l2_masked_image_dir,
-            composite_dir,
-            chunks=config_dict["chunks"],
-            generate_date_images=True,
-            missing_data_value=0,
-        )
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-        tile_log.info("Baseline composite complete.")
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
+        tile_log.info("---------------------------------------------------------------")
+        tile_log.info("Offsetting of cloud masked L2A images for composite complete.")
+        tile_log.info("---------------------------------------------------------------")
+        # I.R. 20220607 END
 
         if config_dict["do_quicklooks"] or config_dict["do_all"]:
             tile_log.info(
@@ -812,7 +750,7 @@ def acd_by_tile_raster(config_path: str,
             tile_log.info(
                 "---------------------------------------------------------------"
             )
-            dirs_for_quicklooks = [composite_dir]
+            dirs_for_quicklooks = [composite_l2_masked_image_dir]
             for main_dir in dirs_for_quicklooks:
                 files = [
                     f.path
@@ -828,9 +766,7 @@ def acd_by_tile_raster(config_path: str,
                             quicklook_dir,
                             os.path.basename(f).split(".")[0] + ".png",
                         )
-                        tile_log.info(
-                            "Creating quicklook: {}".format(quicklook_path)
-                        )
+                        tile_log.info("Creating quicklook: {}".format(quicklook_path))
                         raster_manipulation.create_quicklook(
                             f,
                             quicklook_path,
@@ -840,89 +776,176 @@ def acd_by_tile_raster(config_path: str,
                             bands=[3, 2, 1],
                             scale_factors=[[0, 2000, 0, 255]],
                         )
-            tile_log.info("Quicklooks complete.")
+        tile_log.info("Quicklooks complete.")
 
-        if config_dict["do_delete"]:
+        if config_dict["do_zip"]:
             tile_log.info(
                 "---------------------------------------------------------------"
             )
             tile_log.info(
-                "Deleting intermediate cloud-masked L2A images used for the baseline composite"
+                "Zipping downloaded L2A images for composite after cloud masking and band stacking"
             )
             tile_log.info(
                 "---------------------------------------------------------------"
             )
-            f = composite_l2_masked_image_dir
-            tile_log.info("Deleting {}".format(f))
-            shutil.rmtree(f)
+            filesystem_utilities.zip_contents(composite_l2_image_dir)
             tile_log.info(
                 "---------------------------------------------------------------"
             )
-            tile_log.info("Intermediate file products have been deleted.")
-            tile_log.info("They can be reprocessed from the downloaded L2A images.")
+            tile_log.info("Zipping complete")
             tile_log.info(
                 "---------------------------------------------------------------"
             )
+
+        tile_log.info("---------------------------------------------------------------")
+        tile_log.info(
+            "Building initial cloud-free median composite from directory {}".format(
+                composite_l2_masked_image_dir
+            )
+        )
+        tile_log.info("---------------------------------------------------------------")
+        directory = composite_l2_masked_image_dir
+        masked_file_paths = [
+            f
+            for f in os.listdir(directory)
+            if f.endswith(".tif") and os.path.isfile(os.path.join(directory, f))
+        ]
+
+        if len(masked_file_paths) > 0:
+            raster_manipulation.clever_composite_directory(
+                composite_l2_masked_image_dir,
+                composite_dir,
+                chunks=config_dict["chunks"],
+                generate_date_images=True,
+                missing_data_value=0,
+            )
+            tile_log.info(
+                "---------------------------------------------------------------"
+            )
+            tile_log.info("Baseline composite complete.")
+            tile_log.info(
+                "---------------------------------------------------------------"
+            )
+
+            if config_dict["do_quicklooks"] or config_dict["do_all"]:
+                tile_log.info(
+                    "---------------------------------------------------------------"
+                )
+                tile_log.info("Producing quicklooks.")
+                tile_log.info(
+                    "---------------------------------------------------------------"
+                )
+                dirs_for_quicklooks = [composite_dir]
+                for main_dir in dirs_for_quicklooks:
+                    files = [
+                        f.path
+                        for f in os.scandir(main_dir)
+                        if f.is_file() and os.path.basename(f).endswith(".tif")
+                    ]
+                    # files = [ f.path for f in os.scandir(main_dir) if f.is_file() and os.path.basename(f).endswith(".tif") and "class" in os.path.basename(f) ] # do classification images only
+                    if len(files) == 0:
+                        tile_log.warning("No images found in {}.".format(main_dir))
+                    else:
+                        for f in files:
+                            quicklook_path = os.path.join(
+                                quicklook_dir,
+                                os.path.basename(f).split(".")[0] + ".png",
+                            )
+                            tile_log.info(
+                                "Creating quicklook: {}".format(quicklook_path)
+                            )
+                            raster_manipulation.create_quicklook(
+                                f,
+                                quicklook_path,
+                                width=512,
+                                height=512,
+                                format="PNG",
+                                bands=[3, 2, 1],
+                                scale_factors=[[0, 2000, 0, 255]],
+                            )
+                tile_log.info("Quicklooks complete.")
+
+            if config_dict["do_delete"]:
+                tile_log.info(
+                    "---------------------------------------------------------------"
+                )
+                tile_log.info(
+                    "Deleting intermediate cloud-masked L2A images used for the baseline composite"
+                )
+                tile_log.info(
+                    "---------------------------------------------------------------"
+                )
+                f = composite_l2_masked_image_dir
+                tile_log.info("Deleting {}".format(f))
+                shutil.rmtree(f)
+                tile_log.info(
+                    "---------------------------------------------------------------"
+                )
+                tile_log.info("Intermediate file products have been deleted.")
+                tile_log.info("They can be reprocessed from the downloaded L2A images.")
+                tile_log.info(
+                    "---------------------------------------------------------------"
+                )
+            else:
+                if config_dict["do_zip"]:
+                    tile_log.info(
+                        "---------------------------------------------------------------"
+                    )
+                    tile_log.info(
+                        "Zipping cloud-masked L2A images used for the baseline composite"
+                    )
+                    tile_log.info(
+                        "---------------------------------------------------------------"
+                    )
+                    filesystem_utilities.zip_contents(composite_l2_masked_image_dir)
+                    tile_log.info(
+                        "---------------------------------------------------------------"
+                    )
+                    tile_log.info("Zipping complete")
+                    tile_log.info(
+                        "---------------------------------------------------------------"
+                    )
+
+            tile_log.info(
+                "---------------------------------------------------------------"
+            )
+            tile_log.info(
+                "Compressing tiff files in directory {} and all subdirectories".format(
+                    composite_dir
+                )
+            )
+            tile_log.info(
+                "---------------------------------------------------------------"
+            )
+            for root, dirs, files in os.walk(composite_dir):
+                all_tiffs = [
+                    image_name for image_name in files if image_name.endswith(".tif")
+                ]
+                for this_tiff in all_tiffs:
+                    raster_manipulation.compress_tiff(
+                        os.path.join(root, this_tiff), os.path.join(root, this_tiff)
+                    )
+
+            tile_log.info(
+                "---------------------------------------------------------------"
+            )
+            tile_log.info(
+                "Baseline image composite, file compression, zipping and deletion of"
+            )
+            tile_log.info("intermediate file products (if selected) are complete.")
+            tile_log.info(
+                "---------------------------------------------------------------"
+            )
+
         else:
-            if config_dict["do_zip"]:
-                tile_log.info(
-                    "---------------------------------------------------------------"
+            tile_log.error(
+                "No cloud-masked L2A image products found in {}.".format(
+                    composite_l2_image_dir
                 )
-                tile_log.info(
-                    "Zipping cloud-masked L2A images used for the baseline composite"
-                )
-                tile_log.info(
-                    "---------------------------------------------------------------"
-                )
-                filesystem_utilities.zip_contents(composite_l2_masked_image_dir)
-                tile_log.info(
-                    "---------------------------------------------------------------"
-                )
-                tile_log.info("Zipping complete")
-                tile_log.info(
-                    "---------------------------------------------------------------"
-                )
-
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-        tile_log.info(
-            "Compressing tiff files in directory {} and all subdirectories".format(
-                composite_dir
             )
-        )
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-        for root, dirs, files in os.walk(composite_dir):
-            all_tiffs = [
-                image_name for image_name in files if image_name.endswith(".tif")
-            ]
-            for this_tiff in all_tiffs:
-                raster_manipulation.compress_tiff(
-                    os.path.join(root, this_tiff), os.path.join(root, this_tiff)
-                )
-
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-        tile_log.info(
-            "Baseline image composite, file compression, zipping and deletion of"
-        )
-        tile_log.info("intermediate file products (if selected) are complete.")
-        tile_log.info(
-            "---------------------------------------------------------------"
-        )
-
-    else:
-        tile_log.error(
-            "No cloud-masked L2A image products found in {}.".format(
-                composite_l2_image_dir
+            tile_log.error(
+                "Cannot produce a median composite. Download and cloud-mask some images first."
             )
-        )
-        tile_log.error(
-            "Cannot produce a median composite. Download and cloud-mask some images first."
-        )
 
 # ------------------------------------------------------------------------
     # Step 2: Download change detection images for the specific time window (L2A where available plus additional L1C)

--- a/pyeo_ivan.ini
+++ b/pyeo_ivan.ini
@@ -64,7 +64,7 @@ log_filename = test_acd_parallel_20230524.txt
 credentials_path = /home/i/ir81/credentials/credentials_ir.ini
 
 # conda_environment
-conda_directory = /home/i/ir81/miniconda3/envs
+conda_directory = /home/i/ir81/miniconda3
 # conda_directory = /home/m/mp730/miniconda3/envs
 conda_env_name = pyeo_env
 # conda_env_name = pyeo_prod_0_8_0_env

--- a/pyeo_windows.ini
+++ b/pyeo_windows.ini
@@ -21,7 +21,7 @@ api_key=
 
 # Acquisition dates in the form yyyymmdd
 start_date=20230101
-end_date=20230331
+end_date=20230131
 
 # Dates to download and preprocess for the initial cloud-free composite
 composite_start=20220101
@@ -54,14 +54,15 @@ roi_filename = kfs_roi_subset_c.shp
 geometry_dir = .\geometry
 log_dir = .\log
 log_filename = test_windows_installation_20230603.txt
-credentials_path = .\credentials\credentials_ir.ini
+credentials_path = ..\credentials\credentials_ir.ini
 
 # conda_environment
-conda_directory = C:\Users\ir81\.conda\envs
+conda_directory = C:\Users\ir81\.conda
 conda_env_name = pyeo_env_pcwe
 
 # Path to the sen2cor preprocessor script, L2A_Process. Usually in the bin\ folder of your sen2cor installation.
-sen2cor_path = C:\Users\ir81\Sen2Cor-02.11.00-win64\L2A_Process
+sen2cor_path = C:\Users\ir81\Sen2Cor-02.11.00-win64\L2A_Process.bat
+#sen2cor_path = C:\Users\ir81\Sen2Cor-02.11.00-win64\L2A_Process
 
 
 [raster_processing_parameters]
@@ -104,7 +105,7 @@ output_resolution = 10
 
 
 # ***** STEP 4 DOWNLOAD REFERENCE IMAGES AND BUILD A MEDIAN COMPOSITE ***** 
-do_build_composite = True
+do_build_composite = False
 # set buffer in number of pixels for dilating the SCL cloud mask (recommend 10 pixels of 10 m) for the composite building
 buffer_size_cloud_masking_composite = 10
 # maximum number of images to be downloaded for compositing, in order of least cloud cover
@@ -123,13 +124,9 @@ buffer_size_cloud_masking = 20
 # ***** NOTE: MOVE MODEL SPECIFICATION TO THIS SECTION***** 
 do_build_prob_image = False 
 # do_build_prob_image, consider removing
-do_classify = False
+do_classify = True
 # list of strings with class labels starting from class 1. Must match the trained model that was used.
 class_labels = ["primary forest", "plantation forest", "bare soil", "crops", "grassland", "open water", "burn scar", "cloud", "cloud shadow", "haze", "sparse woodland", "dense woodland", "artificial"]
-# find subsequent changes from any of these classes. Must match the trained model that was used.
-change_from_classes = [1, 2]
-# to any of these classes. Must match the trained model that was used.
-change_to_classes = [3]
 # if sieve is 0, no sieve is applied. If >0, the classification images will be sieved using gdal and all contiguous groups of pixels smaller than this number will be eliminated
 sieve = 0
 # **************************************************************************************************************************
@@ -137,7 +134,11 @@ sieve = 0
 
 # ***** STEP 7: DETECT CHANGES AND BUILD RASTER REPORTS ***** 
 # ***** NOTE: ADD REPORT BINARISATION PARAMETERS TO THIS SECTION MIN_DETECTION; CONSISTENCY ETC.***** 
-do_change = False
+do_change = True
+# find subsequent changes from any of these classes. Must match the trained model that was used.
+change_from_classes = [1, 2]
+# to any of these classes. Must match the trained model that was used.
+change_to_classes = [3]
 # **************************************************************************************************************************
 
 
@@ -159,9 +160,9 @@ do_integrate = False
 
 # ***** STEP 10: FILTER NATIONAL SCOPE VECTORISED FOREST ALERTS ***** 
 do_filter = False
-# if there are any string within counties_of_interest, filtering by county will be attempted
+# If there are any strings within counties_of_interest list, filtering by county will be attempted
 counties_of_interest = []
-#counties_of_interest = ["Kwale", "TransNzoia"]
+# Counties_of_interest = ["Kwale", "TransNzoia"]
 minimum_area_to_report_m2 = 120
 # **************************************************************************************************************************
 


### PR DESCRIPTION
Bugs in the download section for composite building fixed so that credentials.ini is read correctly and available to both data_source options (scihub and dataspace) - this required indenting of lines 163 to 925 so that they fall under the 'if config_dict["build_composite"]' conditional