### PR TITLE
Dataspace uniqueness

### DIFF
--- a/pyeo_1/acd_national.py
+++ b/pyeo_1/acd_national.py
@@ -52,7 +52,6 @@ def automatic_change_detection_national(config_path):
     if config_dict["do_tile_intersection"]:
         tilelist_filepath = acd_roi_tile_intersection(config_dict, acd_log)
 
-
     if config_dict["do_raster"] and config_dict["do_tile_intersection"]:
         acd_log.info("---------------------------------------------------------------")
         acd_log.info("Starting acd_integrated_raster():")
@@ -91,10 +90,10 @@ def automatic_change_detection_national(config_path):
         if config_dict["counties_of_interest"]:
             acd_national_filtering(log=acd_log, config_dict=config_dict)
 
-    if config_dict["do_distribution"]:
-        acd_log.info("---------------------------------------------------------------")
-        acd_log.info("Starting acd_national_distribution()")
-        acd_log.info("---------------------------------------------------------------")
+    # if config_dict["do_distribution"]:
+    #     acd_log.info("---------------------------------------------------------------")
+    #     acd_log.info("Starting acd_national_distribution()")
+    #     acd_log.info("---------------------------------------------------------------")
         # acd_national_distribution()
         # messaging services to Park Rangers (e.g. WhatsApp, Maps2Me)
 

--- a/pyeo_1/apps/acd_national/acd_by_tile_raster.py
+++ b/pyeo_1/apps/acd_national/acd_by_tile_raster.py
@@ -361,23 +361,26 @@ def acd_by_tile_raster(config_path: str,
                     tile_log.info("       {}".format(product))
                 tile_log.info(f"len of L2A products for dataspace is {len(l2a_products['title'])}")
 
-        if download_source == "scihub":
-            if l1c_products.shape[0] > 0 and l2a_products.shape[0] > 0:
-                tile_log.info(
-                    "Filtering out L1C products that have the same 'beginposition' time stamp as an existing L2A product."
-                )
+        if l1c_products.shape[0] > 0 and l2a_products.shape[0] > 0:
+            tile_log.info(
+                "Filtering out L1C products that have the same 'beginposition' time stamp as an existing L2A product."
+            )
+            if download_source == "scihub":
                 (l1c_products,l2a_products,) = queries_and_downloads.filter_unique_l1c_and_l2a_data(df,log=tile_log)
-                tile_log.info(
-                    "--> {} L1C and L2A products with unique 'beginposition' time stamp for the composite:".format(
-                        l1c_products.shape[0] + l2a_products.shape[0]
-                    )
-                )
-                tile_log.info("    {} L1C products".format(l1c_products.shape[0]))
-                tile_log.info("    {} L2A products".format(l2a_products.shape[0]))
-        df = None
 
-        tile_log.info(f"len of L1C products for dataspace is {len(l1c_products['title'])}")
-        tile_log.info(f"len of L2A products for dataspace is {len(l2a_products['title'])}")
+            if download_source == "dataspace":
+                l1c_products = queries_and_downloads.filter_unique_dataspace_products(l1c_products=l1c_products, l2a_products=l2a_products, log=tile_log)
+                                                                                                      
+            # tile_log.info(
+            #     "--> {} L1C and L2A products with unique 'beginposition' time stamp for the composite:".format(
+            #         l1c_products.shape[0] + l2a_products.shape[0]
+            #     )
+            # )
+    
+    
+        df = None
+        tile_log.info(f" {len(l1c_products['title'])} L1C products for the Composite")
+        tile_log.info(f" {len(l2a_products['title'])} L2A products for the Composite")
 
         # Search the local directories, composite/L2A and L1C, checking if scenes have already been downloaded and/or processed whilst checking their dir sizes
         if download_source == "scihub":
@@ -975,7 +978,8 @@ def acd_by_tile_raster(config_path: str,
                     start_date=dataspace_change_start,
                     end_date=dataspace_change_end,
                     area_of_interest=geometry,
-                    max_records=100
+                    max_records=100,
+                    log=tile_log
                 )
             except Exception as error:
                 tile_log.error(f"query_by_polygon received this error: {error}")
@@ -1052,26 +1056,27 @@ def acd_by_tile_raster(config_path: str,
         l2a_products = df[df.processinglevel == "Level-2A"]
         tile_log.info("    {} L1C products".format(l1c_products.shape[0]))
         tile_log.info("    {} L2A products".format(l2a_products.shape[0]))
-        if download_source == "scihub":
-            if l1c_products.shape[0] > 0 and l2a_products.shape[0] > 0:
-                tile_log.info(
-                    "Filtering out L1C products that have the same 'beginposition' time stamp as an existing L2A product."
-                )
-                (
-                    l1c_products,
-                    l2a_products,
-                ) = queries_and_downloads.filter_unique_l1c_and_l2a_data(df)
-                tile_log.info(
-                    "--> {} L1C and L2A products with unique 'beginposition' time stamp for the composite:".format(
-                        l1c_products.shape[0] + l2a_products.shape[0]
-                    )
-                )
-                tile_log.info("    {} L1C products".format(l1c_products.shape[0]))
-                tile_log.info("    {} L2A products".format(l2a_products.shape[0]))
-        df = None
+        
+        if l1c_products.shape[0] > 0 and l2a_products.shape[0] > 0:
+            tile_log.info(
+                "Filtering out L1C products that have the same 'beginposition' time stamp as an existing L2A product."
+            )
+            if download_source == "scihub":
+                (l1c_products,l2a_products,) = queries_and_downloads.filter_unique_l1c_and_l2a_data(df,log=tile_log)
 
-        tile_log.info(f"len of Change L1C products for dataspace is {len(l1c_products['title'])}")
-        tile_log.info(f"len of Change L2A products for dataspace is {len(l2a_products['title'])}")
+            if download_source == "dataspace":
+                l1c_products = queries_and_downloads.filter_unique_dataspace_products(l1c_products=l1c_products, l2a_products=l2a_products, log=tile_log)
+                                                                                                      
+            tile_log.info(
+                "--> {} L1C and L2A products with unique 'beginposition' time stamp for the composite:".format(
+                    l1c_products.shape[0] + l2a_products.shape[0]
+                )
+            )
+        
+        df = None
+        tile_log.info(f" {len(l1c_products['title'])} L1C Change Images")
+        tile_log.info(f" {len(l2a_products['title'])} L2A Change Images")
+
         # TODO: Before the next step, search the composite/L2A and L1C directories whether the scenes have already been downloaded and/or processed and check their dir sizes
         # Remove those already obtained from the list
         if download_source == "scihub":    

--- a/pyeo_dataspace.ini
+++ b/pyeo_dataspace.ini
@@ -73,8 +73,8 @@ sen2cor_path = /home/m/mp730/Downloads/Sen2Cor-02.11.00-Linux64/bin/L2A_Process
 
 [raster_processing_parameters]
 # list of strings with the band name elements of the image file names in "" string notation
-#band_names = ["B02", "B03", "B04", "B08"]
-band_names = ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+band_names = ["B02", "B03", "B04", "B08"]
+#band_names = ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
 # file name pattern to search for when identifying band file locations in "" string notation
 resolution_string = "10m"
 # spatial resolution of the output raster files in metres. Can be any resolution, not just 10, 20 or 60 as in the default band resolutions of Sentinel-2

--- a/pyeo_dataspace_terminal_run.ini
+++ b/pyeo_dataspace_terminal_run.ini
@@ -9,10 +9,6 @@ watch_time_hours = 24
 watch_period_seconds = 60
 # needs to be in the format "nodes=1:ppn=16,vmem=64Gb"
 
-[planet]
-#Your API key for Planet, if you have one.
-api_key=
-
 [forest_sentinel]
 # aoi_name: The name of this area of interest. No spaces.
 # aoi_name=Kenya
@@ -73,8 +69,8 @@ sen2cor_path = /home/m/mp730/Downloads/Sen2Cor-02.11.00-Linux64/bin/L2A_Process
 
 [raster_processing_parameters]
 # list of strings with the band name elements of the image file names in "" string notation
-#band_names = ["B02", "B03", "B04", "B08"]
-band_names = ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
+band_names = ["B02", "B03", "B04", "B08"]
+#band_names = ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B09", "B11", "B12"]
 # file name pattern to search for when identifying band file locations in "" string notation
 resolution_string = "10m"
 # spatial resolution of the output raster files in metres. Can be any resolution, not just 10, 20 or 60 as in the default band resolutions of Sentinel-2
@@ -86,7 +82,7 @@ buffer_size_cloud_masking = 20
 buffer_size_cloud_masking_composite = 10
 
 # maximum number of images to be downloaded for compositing, in order of least cloud cover
-download_limit = 5
+download_limit = 3
 # granules below this size in MB will not be downloaded
 faulty_granule_threshold = 0
 


### PR DESCRIPTION
Changes:

- [x] added `queries_and_downloads.filter_unique_dataspace_products()`
    - [x] this function returns only unique L1C products, as not all Sentinel-2 images are processed to L2A level within CDSE 
    - [x] for some reason, the existing scihub orientated function, `queries_and_downloads.filter_unique_l1c_and_l2a_data()` does not filter dataspace derived L1Cs, returning uncapped L1Cs and L2As. In the interest of time, the alternative unique filtering function was created.  