### PR TITLE
removed pyeo_1 editable install for sepal venv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,6 @@ psutil==5.9.5
 ptyprocess==0.7.0
 pure-eval==0.2.2
 pycparser==2.21
--e git+https://github.com/clcr/pyeo_1.git@3407b1b0bf518426ab18abf32aac1e9ca19e5942#egg=pyeo_1
 Pygments==2.15.1
 pyparsing==3.0.9
 pyproj==3.4.1


### PR DESCRIPTION
-[x] removed pyeo_1 editable install, thus removing `pyeo_1` static install from sepal venv