### PR TITLE
Kml national

### DIFF
--- a/pyeo_1/apps/acd_national/acd_by_tile_vectorisation.py
+++ b/pyeo_1/apps/acd_national/acd_by_tile_vectorisation.py
@@ -37,7 +37,6 @@ def vector_report_generation(config_path: str, tile: str):
     os.chdir(config_dict["pyeo_dir"])
     
     # get other parameters
-    #conda_env_name = config_dict["conda_env_name"]
     epsg = config_dict["epsg"]
     level_1_boundaries_path = config_dict["level_1_boundaries_path"]
 
@@ -117,14 +116,13 @@ def vector_report_generation(config_path: str, tile: str):
                                         path_to_vectorised_binary_filtered=path_vectorised_binary_filtered,
                                         write_csv=False,
                                         write_shapefile=True,
-                                        write_kmlfile=True,
+                                        write_kmlfile=False,
                                         write_pkl=False,
                                         change_report_path=change_report_path,
                                         log=tile_log,
                                         epsg=epsg,
                                         level_1_boundaries_path=level_1_boundaries_path,
                                         tileid=tile,
-                                        # conda_env_name=conda_env_name,
                                         config_dict=config_dict,
                                         delete_intermediates=True,
                                     )
@@ -135,8 +133,6 @@ def vector_report_generation(config_path: str, tile: str):
 
     return(list(output_vector_files))
 
-
-# if run from terminal, do this:
 if __name__ == "__main__":
     # assuming argv[0] is script name, config_path passed as index 1 and tile string as index 2
     vector_report_generation(config_path=sys.argv[1], tile=sys.argv[2])

--- a/pyeo_1/vectorisation.py
+++ b/pyeo_1/vectorisation.py
@@ -609,13 +609,9 @@ def merge_and_calculate_spatial(
     from pathlib import Path
     from pyeo_1.filesystem_utilities import serial_date_to_string
 
-    # switch GDAL installation to geopandas'
-    # gdal_switch(installation="geopandas", config_dict=config_dict)
-
     binary_dec = gpd.read_file(path_to_vectorised_binary_filtered)
 
     # convert first date of change detection in days, to change date
-    # columns_to_apply = ["rb7_min", "rb7_max", "rb7_mean", "rb7_median"]
     columns_to_apply = ["rb4_min", "rb4_max", "rb4_mean", "rb4_median"]
 
     for column in columns_to_apply:
@@ -687,7 +683,7 @@ def merge_and_calculate_spatial(
         log.info(f"Shapefile written as ESRI Shapefile, to:  {shp_fname}")
         output_vector_files.append(shp_fname)
         
-    if write_kmlfile:
+    if write_kml:
         fiona.supported_drivers['KML'] = 'rw'
         merged.to_file(kml_fname, driver='KML')
         log.info(f"Vector file written as kml file, to:  {kml_fname}")
@@ -717,8 +713,5 @@ def merge_and_calculate_spatial(
                 os.remove(file)
         except:
             log.info("Could not delete intermediate files")
-
-    # "reset" gdal and proj installation back to default (which is GDAL's GDAL and PROJ_LIB installation)
-    # gdal_switch(installation="gdal_api", config_dict=config_dict)
     
     return(list(output_vector_files))


### PR DESCRIPTION
- [x] turned `write_kml` argument to false when called in the `acd_by_tile_vectorisation` step, as kml not needed at this stage.
- [x] added `write_kml` argument to `acd_national.py`. this is True.
- [x] corrected typo from `kml_creation` for kml file writing. 